### PR TITLE
david-whitlatch/APPEALS-44794

### DIFF
--- a/app/models/builders/decision_review_created/request_issue_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_builder.rb
@@ -80,6 +80,7 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
     assign_vacols_sequence_id
     assign_nonrating_issue_bgs_id
     assign_type
+    assign_nonrating_issue_bgs_source
   end
 
   def calculate_methods
@@ -244,6 +245,10 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
 
   def assign_nonrating_issue_bgs_id
     @request_issue.nonrating_issue_bgs_id = issue.prior_non_rating_decision_id&.to_s
+  end
+
+  def assign_nonrating_issue_bgs_source
+    @request_issue.nonrating_issue_bgs_source = issue.prior_decision_source
   end
 
   # exception thrown if an unrecognized eligibility_result is passed in

--- a/app/models/builders/decision_review_created/request_issue_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_builder.rb
@@ -248,7 +248,7 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
   end
 
   def assign_nonrating_issue_bgs_source
-    @request_issue.nonrating_issue_bgs_source = issue.prior_decision_source
+    @request_issue.nonrating_issue_bgs_source = issue.prior_decision_source&.to_s
   end
 
   # exception thrown if an unrecognized eligibility_result is passed in

--- a/app/models/builders/decision_review_created/request_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_collection_builder.rb
@@ -6,7 +6,7 @@ class Builders::DecisionReviewCreated::RequestIssueCollectionBuilder
   # issues with this eligibility_result are not included in the caseflow payload
   # caseflow does not track or have a concept of this when determining ineligible_reason
   CONTESTED = "CONTESTED"
-  RATING = "rating"
+  RATING = "RATING"
 
   def self.build(decision_review_created)
     builder = new(decision_review_created)
@@ -62,7 +62,7 @@ class Builders::DecisionReviewCreated::RequestIssueCollectionBuilder
   end
 
   def rating_ep_code_category?
-    @decision_review_created.ep_code_category == RATING
+    @decision_review_created.ep_code_category.upcase == RATING
   end
 
   def at_least_one_valid_bis_issue?

--- a/app/models/virtual/decision_review_created/request_issue.rb
+++ b/app/models/virtual/decision_review_created/request_issue.rb
@@ -8,5 +8,5 @@ class DecisionReviewCreated::RequestIssue
                 :is_unidentified, :unidentified_issue_text, :nonrating_issue_category, :nonrating_issue_description,
                 :untimely_exemption, :untimely_exemption_notes, :vacols_id, :vacols_sequence_id, :benefit_type,
                 :closed_at, :closed_status, :contested_rating_issue_diagnostic_code, :ramp_claim_id,
-                :rating_issue_associated_at, :type, :nonrating_issue_bgs_id
+                :rating_issue_associated_at, :type, :nonrating_issue_bgs_id, :nonrating_issue_bgs_source
 end

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -111,7 +111,8 @@ class DecisionReviewIssue
     "legacy_appeal_id" => [String, NilClass],
     "legacy_appeal_issue_id" => [Integer, NilClass],
     "source_contention_id_for_remand" => [Integer, NilClass],
-    "source_claim_id_for_remand" => [Integer, NilClass]
+    "source_claim_id_for_remand" => [Integer, NilClass],
+    "prior_decision_source" => [String, NilClass]
 
   }
   # rubocop:enable Style/MutableConstant

--- a/docker-bin/VBMS_CEST_UAT_DECISION_REVIEW_INTAKE.avsc
+++ b/docker-bin/VBMS_CEST_UAT_DECISION_REVIEW_INTAKE.avsc
@@ -153,6 +153,7 @@
     {
       "name": "autoRemand",
       "type": "boolean",
+      "default": false,
       "doc": "True/false value to indicate whether or not this decision review is an automatically established remand."
     },
     {
@@ -184,6 +185,15 @@
               "name": "unidentified",
               "type": "boolean",
               "doc": "Indicates whether this issue was unidentified. If true, both PriorRatingDecisionId and PriorNonRatingDecisionId will be null."
+            },
+            {
+              "name": "priorDecisionSource",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null,
+              "doc": "The source of the prior decision."
             },
             {
               "name": "priorRatingDecisionId",
@@ -271,6 +281,15 @@
               ],
               "default": null,
               "doc": "The rating percentage of the prior decision that is being reviewed by this issue"
+            },
+            {
+              "name": "priorDecisionRatingSn",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null,
+              "doc": "If the decision originated from VBMS-Ratings, then this is the rating sequence number. An identifier for the rating decision (on the specific decision type itself, disability evaluation, competency, smc, etc). If the decision originated from VBMS-Awards, no ratingSn is associated to the decision."
             },
             {
               "name": "eligible",
@@ -388,15 +407,6 @@
               ],
               "default": null,
               "doc": "The ID of the contention that was assigned a disposition that triggered the auto-establishment of this remand decision review, if applicable."
-            },
-            {
-              "name": "priorDecisionRatingSn",
-              "type": [
-                "null",
-                "string"
-              ],
-              "default": null,
-              "doc": "If the decision originated from VBMS-Ratings, then this is the rating sequence number. An identifier for the rating decision (on the specific decision type itself, disability evaluation, competency, smc, etc). If the decision originated from VBMS-Awards, no ratingSn is associated to the decision."
             }
           ]
         }

--- a/lib/kafka_message_generators/decision_review_created_events.rb
+++ b/lib/kafka_message_generators/decision_review_created_events.rb
@@ -546,7 +546,8 @@ module KafkaMessageGenerators
       contested_with_additional_issue = create_contested_with_additional_issue(issue_type, code)
       decision_source_message = create_decision_source_message(issue_type, code)
 
-      identified_messages + decision_type_messages + eligible_with_two_issues + contested_with_additional_issue + decision_source_message
+      identified_messages + decision_type_messages + eligible_with_two_issues + contested_with_additional_issue +
+        decision_source_message
     end
 
     def create_eligible_with_two_issues(issue_type, code)

--- a/lib/kafka_message_generators/decision_review_created_events.rb
+++ b/lib/kafka_message_generators/decision_review_created_events.rb
@@ -544,8 +544,9 @@ module KafkaMessageGenerators
       decision_type_messages = create_decision_type_messages(issue_type, code)
       eligible_with_two_issues = create_eligible_with_two_issues(issue_type, code)
       contested_with_additional_issue = create_contested_with_additional_issue(issue_type, code)
+      decision_source_message = create_decision_source_message(issue_type, code)
 
-      identified_messages + decision_type_messages + eligible_with_two_issues + contested_with_additional_issue
+      identified_messages + decision_type_messages + eligible_with_two_issues + contested_with_additional_issue + decision_source_message
     end
 
     def create_eligible_with_two_issues(issue_type, code)
@@ -556,6 +557,12 @@ module KafkaMessageGenerators
 
     def create_contested_with_additional_issue(issue_type, code)
       drc = create_drc_message("ineligible_#{issue_type}_contested_with_additional_issue", code)
+
+      [drc]
+    end
+
+    def create_decision_source_message(issue_type, code)
+      drc = create_drc_message("eligible_#{issue_type}_with_decision_source", code)
 
       [drc]
     end

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -33,7 +33,8 @@ FactoryBot.define do
             "legacy_appeal_id" => nil,
             "legacy_appeal_issue_id" => nil,
             "source_contention_id_for_remand" => nil,
-            "source_claim_id_for_remand" => nil
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => nil
           },
           {
             "contention_id" => 123_456_790,
@@ -60,7 +61,8 @@ FactoryBot.define do
             "legacy_appeal_id" => nil,
             "legacy_appeal_issue_id" => nil,
             "source_contention_id_for_remand" => nil,
-            "source_claim_id_for_remand" => nil
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => nil
           }
         ]
       end

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -544,6 +544,41 @@ FactoryBot.define do
       end
     end
 
+    trait :eligible_nonrating_hlr_with_decision_source do
+      decision_review_issues do
+        [
+          {
+            "contention_id" => 123_456_791,
+            "prior_caseflow_decision_issue_id" => nil,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => false,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => 13,
+            "prior_decision_award_event_id" => nil,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC:",
+            "prior_decision_notification_date" => "2020-08-25",
+            "prior_decision_date" => "2020-08-25",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => true,
+            "time_override_reason" => "good cause exemption",
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => nil,
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE"
+          }
+        ]
+      end
+    end
+
     trait :eligible_nonrating_hlr_legacy do
       decision_review_issues do
         [
@@ -1133,6 +1168,41 @@ FactoryBot.define do
       end
     end
 
+    trait :eligible_nonrating_hlr_unidentified_with_decision_source do
+      decision_review_issues do
+        [
+          {
+            "contention_id" => 12_345_980,
+            "prior_caseflow_decision_issue_id" => nil,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => true,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => nil,
+            "prior_decision_award_event_id" => nil,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC",
+            "prior_decision_notification_date" => "2023-08-01",
+            "prior_decision_date" => "2023-08-01",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => nil,
+            "time_override_reason" => nil,
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => nil,
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE"
+          }
+        ]
+      end
+    end
+
     trait :eligible_nonrating_hlr_unidentified_veteran_claimant do
       eligible_nonrating_hlr_unidentified
     end
@@ -1289,6 +1359,41 @@ FactoryBot.define do
             "legacy_appeal_issue_id" => nil,
             "source_contention_id_for_remand" => nil,
             "source_claim_id_for_remand" => nil
+          }
+        ]
+      end
+    end
+
+    trait :eligible_decision_issue_prior_nonrating_hlr_with_decision_source do
+      decision_review_issues do
+        [
+          {
+            "contention_id" => 123_456_791,
+            "prior_caseflow_decision_issue_id" => 20,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => false,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => 13,
+            "prior_decision_award_event_id" => nil,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC",
+            "prior_decision_notification_date" => "2020-08-25",
+            "prior_decision_date" => "2020-08-25",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => true,
+            "time_override_reason" => "good cause exemption",
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => nil,
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE"
           }
         ]
       end

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -28,5 +28,6 @@ FactoryBot.define do
     rating_issue_associated_at { Time.now.utc }
     type { "RatingRequestIssue" }
     nonrating_issue_bgs_id { nil }
+    nonrating_issue_bgs_source { nil }
   end
 end

--- a/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
@@ -64,7 +64,7 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
       allow(Karafka.producer).to receive(:produce_sync)
     end
 
-    it "publishes 5897 messages to the DecisionReviewCreated topic" do
+    it "publishes 5931 messages to the DecisionReviewCreated topic" do
       subject
       expect(Karafka.producer).to have_received(:produce_sync).exactly(5897).times do |args|
         expect(args[:topic]).to eq("VBMS_CEST_UAT_DECISION_REVIEW_INTAKE")
@@ -104,8 +104,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
   describe "#create_messages" do
     subject { decision_review_created_events.send(:create_messages) }
-    it "creates 5897 messages" do
-      expect(subject.flatten.count).to eq(5897)
+    it "creates 5931 messages" do
+      expect(subject.flatten.count).to eq(5931)
     end
   end
 
@@ -118,8 +118,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
   describe "#create_nonrating_messages" do
     subject { decision_review_created_events.send(:create_nonrating_messages) }
-    it "creates 3048 rating messages" do
-      expect(subject.flatten.count).to eq(3048)
+    it "creates 3082 rating messages" do
+      expect(subject.flatten.count).to eq(3082)
     end
   end
 
@@ -715,8 +715,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
     subject { decision_review_created_events.send(:create_nonrating_ep_code_messages, ep_codes) }
     let(:ep_codes) { nonrating_ep_codes }
 
-    it "creates 3048 messages" do
-      expect(subject.flatten.count).to eq(3048)
+    it "creates 3082 messages" do
+      expect(subject.flatten.count).to eq(3082)
     end
   end
 
@@ -725,15 +725,15 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
     context "when the decision review is a supplemental claim" do
       let(:code) { sc_nonrating_ep_code }
-      it "creates 88 messages for the sc nonrating ep code" do
-        expect(subject.flatten.count).to eq(88)
+      it "creates 89 messages for the sc nonrating ep code" do
+        expect(subject.flatten.count).to eq(89)
       end
     end
 
     context "when the decision review is a higher level review" do
       let(:code) { hlr_nonrating_ep_code }
-      it "creates 92 messages for the hlr nonrating ep code" do
-        expect(subject.flatten.count).to eq(92)
+      it "creates 93 messages for the hlr nonrating ep code" do
+        expect(subject.flatten.count).to eq(93)
       end
     end
   end
@@ -743,15 +743,15 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
     context "when the decision review is a supplemental claim" do
       let(:code) { sc_nonrating_ep_code }
-      it "creates 58 messages for the sc rating ep code" do
-        expect(subject.flatten.count).to eq(58)
+      it "creates 59 messages for the sc rating ep code" do
+        expect(subject.flatten.count).to eq(59)
       end
     end
 
     context "when the decision review is a higher level review" do
       let(:code) { hlr_nonrating_ep_code }
-      it "creates 60 messages for each hlr rating ep code" do
-        expect(subject.flatten.count).to eq(60)
+      it "creates 61 messages for each hlr rating ep code" do
+        expect(subject.flatten.count).to eq(61)
       end
     end
   end
@@ -801,8 +801,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
         context "when the issue is a nonrating issue" do
           let(:issue_type) { "nonrating_hlr" }
-          it "creates 58 messages for the nonrating issue" do
-            expect(subject.flatten.count).to eq(58)
+          it "creates 59 messages for the nonrating issue" do
+            expect(subject.flatten.count).to eq(59)
           end
         end
 
@@ -819,8 +819,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
         context "when the issue is a nonrating issue" do
           let(:issue_type) { "nonrating_hlr" }
-          it "creates 60 messages for the nonrating issue" do
-            expect(subject.flatten.count).to eq(60)
+          it "creates 61 messages for the nonrating issue" do
+            expect(subject.flatten.count).to eq(61)
           end
         end
 
@@ -854,8 +854,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
       context "when the issue does not have an associated decision issue" do
         let(:issue_type) { "nonrating_hlr" }
-        it "creates 44 messages" do
-          expect(subject.flatten.count).to eq(44)
+        it "creates 45 messages" do
+          expect(subject.flatten.count).to eq(45)
         end
       end
     end
@@ -911,8 +911,8 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
       context "when the issue does ont have an associated decision issue" do
         let(:issue_type) { "nonrating_hlr" }
 
-        it "returns 44 messages" do
-          expect(subject.flatten.count).to eq(44)
+        it "returns 45 messages" do
+          expect(subject.flatten.count).to eq(45)
         end
       end
     end

--- a/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
@@ -118,7 +118,7 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
   describe "#create_nonrating_messages" do
     subject { decision_review_created_events.send(:create_nonrating_messages) }
-    it "creates 3082 rating messages" do
+    it "creates 3082 nonrating messages" do
       expect(subject.flatten.count).to eq(3082)
     end
   end

--- a/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
@@ -66,7 +66,7 @@ describe KafkaMessageGenerators::DecisionReviewCreatedEvents do
 
     it "publishes 5931 messages to the DecisionReviewCreated topic" do
       subject
-      expect(Karafka.producer).to have_received(:produce_sync).exactly(5897).times do |args|
+      expect(Karafka.producer).to have_received(:produce_sync).exactly(5931).times do |args|
         expect(args[:topic]).to eq("VBMS_CEST_UAT_DECISION_REVIEW_INTAKE")
       end
     end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -52,6 +52,7 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(subject.instance_variable_defined?(:@rating_issue_associated_at)).to be_truthy
       expect(subject.instance_variable_defined?(:@type)).to be_truthy
       expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_id)).to be_truthy
+      expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_source)).to be_truthy
     end
 
     it "returns the Request Issue" do
@@ -98,6 +99,7 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(builder).to receive(:assign_vacols_sequence_id)
       expect(builder).to receive(:assign_nonrating_issue_bgs_id)
       expect(builder).to receive(:assign_type)
+      expect(builder).to receive(:assign_nonrating_issue_bgs_source)
 
       builder.send(:assign_methods)
     end
@@ -122,6 +124,25 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(builder).to receive(:calculate_rating_issue_associated_at)
 
       builder.send(:calculate_methods)
+    end
+  end
+
+  describe "#assign_nonrating_issue_bgs_source" do
+    subject { builder.send(:assign_nonrating_issue_bgs_source) }
+
+    context "when the issue has a prior_decision_rating_sn value" do
+      let(:decision_review_created) { build(:decision_review_created, :eligible_nonrating_hlr_with_decision_source) }
+
+      it "assigns the Request Issue's nonrating_issue_bgs_source to"\
+         " issue.prior_decision_source converted to a string" do
+        expect(subject).to eq(issue.prior_decision_source.to_s)
+      end
+    end
+
+    context "when the issue does not have a prior_decision_source value" do
+      it "assigns the Request Issue's nonrating_issue_bgs_source to nil" do
+        expect(subject).to eq(nil)
+      end
     end
   end
 

--- a/spec/models/virtual/decision_review_created/request_issue_spec.rb
+++ b/spec/models/virtual/decision_review_created/request_issue_spec.rb
@@ -35,5 +35,6 @@ describe DecisionReviewCreated::RequestIssue do
     expect(request_issue.rating_issue_associated_at).to eq(Time.now.utc)
     expect(request_issue.type).to eq("RatingRequestIssue")
     expect(request_issue.nonrating_issue_bgs_id).to eq(nil)
+    expect(request_issue.nonrating_issue_bgs_source).to eq(nil)
   end
 end

--- a/spec/models/virtual/transformers/decision_review_created_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_created_spec.rb
@@ -70,6 +70,7 @@ describe Transformers::DecisionReviewCreated do
             expect(issue.soc_opt_in).to eq(nil)
             expect(issue.legacy_appeal_id).to eq(nil)
             expect(issue.legacy_appeal_issue_id).to eq(nil)
+            expect(issue.prior_decision_source).to eq(nil)
           when 123_456_790
             expect(issue.contention_id).to eq(123_456_790)
             expect(issue.prior_caseflow_decision_issue_id).to eq(nil)
@@ -93,6 +94,7 @@ describe Transformers::DecisionReviewCreated do
             expect(issue.soc_opt_in).to eq(nil)
             expect(issue.legacy_appeal_id).to eq(nil)
             expect(issue.legacy_appeal_issue_id).to eq(nil)
+            expect(issue.prior_decision_source).to eq(nil)
           end
         end
       end

--- a/spec/services/avro_deserializer_service_spec.rb
+++ b/spec/services/avro_deserializer_service_spec.rb
@@ -63,7 +63,8 @@ describe AvroDeserializerService do
           "prior_decision_award_event_id" => nil,
           "prior_decision_rating_profile_date" => nil,
           "source_contention_id_for_remand" => 1,
-          "source_claim_id_for_remand" => 1
+          "source_claim_id_for_remand" => 1,
+          "prior_decision_source" => nil
         },
         {
           "contention_id" => 987_654_321,
@@ -90,7 +91,8 @@ describe AvroDeserializerService do
           "prior_decision_award_event_id" => nil,
           "prior_decision_rating_profile_date" => nil,
           "source_contention_id_for_remand" => 1,
-          "source_claim_id_for_remand" => 1
+          "source_claim_id_for_remand" => 1,
+          "prior_decision_source" => nil
         }
       ]
     }


### PR DESCRIPTION
Resolves [Add priorDecisionSource attribute to the DecisionReviewCreated event](https://jira.devops.va.gov/browse/APPEALS-44794)

# Description
Added priorDecisionSource to the Kafka Avro. Additionally, make changes to related models and message generators to account for the new data point.

## Acceptance Criteria
- [x] DecisionReviewCreated Avro will need to be updated with latest from C & P
- [x] DecisionReviewCreated Active Model needs to be updated to include new attribute priorDecisionSource.
- [x] RequestIssueBuilder will need an assignment statement for nonrating_issue_bgs_source to have priorDecisionSource value.
- [x] RSPEC will need to be updated
- [x] message publishing seeding wil need to be updated.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added