### PR TITLE
eli/APPEALS-44945-v2

### DIFF
--- a/app/models/builders/decision_review_created/request_issue_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_builder.rb
@@ -6,6 +6,7 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
   attr_reader :decision_review_created, :issue, :request_issue
 
   REQUEST_ISSUE = "RequestIssue"
+  NONRATING_EP_CODE_CATEGORY = "NON-RATING"
 
   # the date AMA was launched
   # used to determine if "TIME_RESTRICTION" eligibility_result matches "before_ama" or "untimely" ineligible_reason
@@ -73,13 +74,13 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
     assign_contested_rating_decision_reference_id
     assign_contested_rating_issue_reference_id
     assign_contested_decision_issue_id
-    assign_is_unidentified
     assign_untimely_exemption
     assign_untimely_exemption_notes
     assign_vacols_id
     assign_vacols_sequence_id
     assign_nonrating_issue_bgs_id
     assign_type
+    assign_nonrating_issue_bgs_source
   end
 
   def calculate_methods
@@ -98,6 +99,7 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
     calculate_contested_rating_issue_diagnostic_code
     calculate_rating_issue_associated_at
     calculate_ramp_claim_id
+    calculate_is_unidentified
   end
 
   # EP codes ending in "PMC" are pension, otherwise "compensation"
@@ -167,24 +169,26 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
     @request_issue.ineligible_reason = determine_ineligible_reason
   end
 
-  def assign_is_unidentified
-    @request_issue.is_unidentified = unidentified?
+  # caseflow expects unidentified issues to be rating
+  # if the issue is nonrating, assign to 'false'
+  def calculate_is_unidentified
+    @request_issue.is_unidentified = nonrating_ep_code? ? false : unidentified?
   end
 
-  # only populate if issue is unidentified
+  # only populate if issue is unidentified rating
   def calculate_unidentified_issue_text
-    @request_issue.unidentified_issue_text =  unidentified? ? issue.prior_decision_text : nil
+    @request_issue.unidentified_issue_text =  (unidentified? && !nonrating_ep_code?) ? issue.prior_decision_text : nil
   end
 
-  # only populate if issue is nonrating
+  # always populate if ep_code_category is "NON-RATING"
   def calculate_nonrating_issue_category
-    @request_issue.nonrating_issue_category = nonrating? ? issue.prior_decision_type : nil
+    @request_issue.nonrating_issue_category = nonrating_ep_code? ? issue.prior_decision_type : nil
   end
 
   # only populate for issues that are nonrating and do not have an associated caseflow decision issue
   def calculate_nonrating_issue_description
     @request_issue.nonrating_issue_description =
-      if nonrating? && !decision_issue?
+      if nonrating_ep_code? && !decision_issue?
         remove_duplicate_prior_decision_type_text
       end
   end
@@ -244,6 +248,10 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
 
   def assign_nonrating_issue_bgs_id
     @request_issue.nonrating_issue_bgs_id = issue.prior_non_rating_decision_id&.to_s
+  end
+
+  def assign_nonrating_issue_bgs_source
+    @request_issue.nonrating_issue_bgs_source = issue.prior_decision_source&.to_s
   end
 
   # exception thrown if an unrecognized eligibility_result is passed in
@@ -401,6 +409,10 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder
 
   def decision_issue?
     !!issue.prior_caseflow_decision_issue_id
+  end
+
+  def nonrating_ep_code?
+    !!(decision_review_created.ep_code_category.upcase == NONRATING_EP_CODE_CATEGORY)
   end
 
   def determine_benefit_type

--- a/spec/models/builders/decision_review_created/end_product_establishment_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/end_product_establishment_builder_spec.rb
@@ -6,6 +6,8 @@ describe Builders::DecisionReviewCreated::EndProductEstablishmentBuilder do
   let!(:event) { create(:decision_review_created_event, message_payload: decision_review_created.to_json) }
   let!(:event_id) { event.id }
   let(:ready_to_work_status) { "RW" }
+  let(:pending_status) { "PEND" }
+  let(:ready_for_decision_status) { "RFD" }
   let(:veteran_bis_record) do
     {
       file_number: decision_review_created.file_number,
@@ -278,8 +280,24 @@ describe Builders::DecisionReviewCreated::EndProductEstablishmentBuilder do
     end
 
     describe "#_calculate_synced_status" do
-      it "should assign a synced status to the epe instance" do
-        expect(builder.end_product_establishment.synced_status).to eq(ready_to_work_status)
+      context "decision_review_created has 'Open' for claim_lifecycle_status" do
+        let(:decision_review_created) { build(:decision_review_created, claim_lifecycle_status: "Open") }
+        it "should assign a synced status of 'PEND' to the epe instance" do
+          expect(builder.end_product_establishment.synced_status).to eq(pending_status)
+        end
+      end
+
+      context "decision_review_created has 'Ready to Work' for claim_lifecycle_status" do
+        it "should assign a synced status of 'RW' to the epe instance" do
+          expect(builder.end_product_establishment.synced_status).to eq(ready_to_work_status)
+        end
+      end
+
+      context "decision_review_created has 'Ready for Decision' for claim_lifecycle_status" do
+        let(:decision_review_created) { build(:decision_review_created, claim_lifecycle_status: "Ready for Decision") }
+        it "should assign a synced status of 'RFD' to the epe instance" do
+          expect(builder.end_product_establishment.synced_status).to eq(ready_for_decision_status)
+        end
       end
     end
 

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -52,6 +52,7 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(subject.instance_variable_defined?(:@rating_issue_associated_at)).to be_truthy
       expect(subject.instance_variable_defined?(:@type)).to be_truthy
       expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_id)).to be_truthy
+      expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_source)).to be_truthy
     end
 
     it "returns the Request Issue" do
@@ -91,13 +92,13 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(builder).to receive(:assign_contested_rating_decision_reference_id)
       expect(builder).to receive(:assign_contested_rating_issue_reference_id)
       expect(builder).to receive(:assign_contested_decision_issue_id)
-      expect(builder).to receive(:assign_is_unidentified)
       expect(builder).to receive(:assign_untimely_exemption)
       expect(builder).to receive(:assign_untimely_exemption_notes)
       expect(builder).to receive(:assign_vacols_id)
       expect(builder).to receive(:assign_vacols_sequence_id)
       expect(builder).to receive(:assign_nonrating_issue_bgs_id)
       expect(builder).to receive(:assign_type)
+      expect(builder).to receive(:assign_nonrating_issue_bgs_source)
 
       builder.send(:assign_methods)
     end
@@ -120,8 +121,28 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(builder).to receive(:calculate_contested_rating_issue_diagnostic_code)
       expect(builder).to receive(:calculate_ramp_claim_id)
       expect(builder).to receive(:calculate_rating_issue_associated_at)
+      expect(builder).to receive(:calculate_is_unidentified)
 
       builder.send(:calculate_methods)
+    end
+  end
+
+  describe "#assign_nonrating_issue_bgs_source" do
+    subject { builder.send(:assign_nonrating_issue_bgs_source) }
+
+    context "when the issue has a prior_decision_rating_sn value" do
+      let(:decision_review_created) { build(:decision_review_created, :eligible_nonrating_hlr_with_decision_source) }
+
+      it "assigns the Request Issue's nonrating_issue_bgs_source to"\
+         " issue.prior_decision_source converted to a string" do
+        expect(subject).to eq(issue.prior_decision_source.to_s)
+      end
+    end
+
+    context "when the issue does not have a prior_decision_source value" do
+      it "assigns the Request Issue's nonrating_issue_bgs_source to nil" do
+        expect(subject).to eq(nil)
+      end
     end
   end
 
@@ -694,36 +715,81 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
     end
   end
 
-  describe "#assign_is_unidentified" do
-    subject { builder.send(:assign_is_unidentified) }
-    context "when the issue has unidentified as true" do
-      let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_unidentified) }
+  describe "#calculate_is_unidentified" do
+    subject { builder.send(:calculate_is_unidentified) }
 
-      it "sets the Request Issue's is_unidentified to true" do
-        expect(subject).to eq true
+    context "decision_review_created has 'NON-RATING' for ep_code_category" do
+      context "issue has true for unidentified" do
+        let(:decision_review_created) { build(:decision_review_created, :eligible_nonrating_hlr_unidentified) }
+
+        it "sets is_unidentified to false" do
+          expect(subject).to eq false
+        end
+      end
+
+      context "issue has false for unidentified" do
+        it "sets is_unidentified to false" do
+          expect(subject).to eq false
+        end
       end
     end
 
-    context "when the issue has unidentified as false" do
-      it "sets the Request Issue's is_unidentified to false" do
-        expect(subject).to eq false
+    context "decision_review_created does not have 'NON-RATING' for ep_code_category" do
+      context "issue has true for unidentified" do
+        let(:decision_review_created) do
+          build(:decision_review_created, :eligible_rating_hlr_unidentified_veteran_claimant)
+        end
+
+        it "sets is_unidentified to true" do
+          expect(subject).to eq true
+        end
+      end
+
+      context "issue has false for unidentified" do
+        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_veteran_claimant) }
+
+        it "sets is_unidentified to false" do
+          expect(subject).to eq false
+        end
       end
     end
   end
 
   describe "#calculate_unidentified_issue_text" do
     subject { builder.send(:calculate_unidentified_issue_text) }
-    context "when the issue is unidentified" do
-      let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_unidentified) }
+    context "decision_review_created has 'NON-RATING' for ep_code_category" do
+      context "issue has true for unidentified" do
+        let(:decision_review_created) { build(:decision_review_created, :eligible_nonrating_hlr_unidentified) }
 
-      it "sets the Request Issue's unidentified_issue_text to issue.prior_decision_text" do
-        expect(subject).to eq(issue.prior_decision_text)
+        it "sets unidentified_issue_text to nil" do
+          expect(subject).to eq nil
+        end
+      end
+
+      context "issue has false for unidentified" do
+        it "sets unidentified_issue_text to nil" do
+          expect(subject).to eq nil
+        end
       end
     end
 
-    context "when the issue is identified" do
-      it "sets the Request Issue's unidentified_issue_text to nil" do
-        expect(subject).to eq nil
+    context "decision_review_created does not have 'NON-RATING' for ep_code_category" do
+      context "issue has true for unidentified" do
+        let(:decision_review_created) do
+          build(:decision_review_created, :eligible_rating_hlr_unidentified_veteran_claimant)
+        end
+
+        it "sets unidentified_issue_text to the issue's prior_decision_text" do
+          expect(subject).to eq(issue.prior_decision_text)
+        end
+      end
+
+      context "issue has false for unidentified" do
+        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_veteran_claimant) }
+
+        it "sets unidentified_issue_text to nil" do
+          expect(subject).to eq nil
+        end
       end
     end
   end
@@ -747,76 +813,47 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
 
   describe "#calculate_nonrating_issue_category" do
     subject { builder.send(:calculate_nonrating_issue_category) }
-    context "when the issue is nonrating" do
-      context "nonrating" do
-        it "sets the Request Issue's nonrating_issue_category to issue.prior_decision_type" do
-          expect(subject).to eq(issue.prior_decision_type)
-        end
-      end
-
-      context "decision issue associated with a nonrating issue" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_decision_issue_prior_nonrating_hlr) }
-        it "sets the Request Issue's nonrating_issue_category to issue.prior_decision_type" do
-          expect(subject).to eq(issue.prior_decision_type)
-        end
+    context "decision_review_created has 'NON-RATING' for ep_code_category" do
+      it "sets nonrating_issue_category to issue's prior_decision_type" do
+        expect(subject).to eq(issue.prior_decision_type)
       end
     end
 
-    context "when the issue is NOT nonrating" do
-      context "rating" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr) }
-        it "sets the Request Issue's nonrating_issue_category to nil" do
-          expect(subject).to eq nil
-        end
-      end
+    context "decision_review_created does not have 'NON-RATING' for ep_code_category" do
+      let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_veteran_claimant) }
 
-      context "rating decision" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_decision_hlr) }
-        it "sets the Request Issue's nonrating_issue_category to nil" do
-          expect(subject).to eq nil
-        end
-      end
-
-      context "decision issue associated with a rating issue" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_decision_issue_prior_rating_hlr) }
-        it "sets the Request Issue's nonrating_issue_category to nil" do
-          expect(subject).to eq nil
-        end
-      end
-
-      context "unidentified" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_unidentified) }
-        it "sets the Request Issue's nonrating_issue_category to nil" do
-          expect(subject).to eq nil
-        end
+      it "sets nonrating_issue_category to nil" do
+        expect(subject).to eq nil
       end
     end
   end
 
   describe "#calculate_nonrating_issue_description" do
     subject { builder.send(:calculate_nonrating_issue_description) }
-    context "when issue is nonrating and doesn't have a value for prior_caseflow_decision_issue_id" do
-      let(:duplicate_text_removed_from_prior_decision_text) do
-        "Service connection for tetnus denied"
+    context "decision_review_created has 'NON-RATING' for ep_code_category" do
+      context "issue doesn't have a value for prior_caseflow_decision_issue_id" do
+        let(:duplicate_text_removed_from_prior_decision_text) do
+          "Service connection for tetnus denied"
+        end
+
+        it "sets the Request Issue's nonrating_issue_description to issue.prior_decision_text with"\
+          " duplicate prior_decision_type text removed" do
+          expect(subject).to eq(duplicate_text_removed_from_prior_decision_text)
+        end
       end
 
-      it "sets the Request Issue's nonrating_issue_description to issue.prior_decision_text with"\
-       " duplicate prior_decision_type text removed" do
-        expect(subject).to eq(duplicate_text_removed_from_prior_decision_text)
+      context "issue does have a value for prior_caseflow_decision_issue_id" do
+        let(:decision_review_created) { build(:decision_review_created, :eligible_decision_issue_prior_nonrating_hlr) }
+
+        it "sets the Request Issue's nonrating_issue_description to nil" do
+          expect(subject).to eq nil
+        end
       end
     end
 
-    context "when the issue is nonrating and DOES have a value for prior_caseflow_decision_issue_id" do
-      let(:decision_review_created) { build(:decision_review_created, :eligible_decision_issue_prior_nonrating_hlr) }
-
-      it "sets the Request Issue's nonrating_issue_description to nil" do
-        expect(subject).to eq nil
-      end
-    end
-
-    context "when the issue is NOT nonrating" do
+    context "decision_review_created does not have 'NON-RATING' for ep_code_category" do
       context "rating" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr) }
+        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_veteran_claimant) }
 
         it "sets the Request Issue's nonrating_issue_description to nil" do
           expect(subject).to eq nil
@@ -824,7 +861,9 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       end
 
       context "rating decision" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_decision_hlr) }
+        let(:decision_review_created) do
+          build(:decision_review_created, :eligible_rating_decision_hlr_veteran_claimant)
+        end
 
         it "sets the Request Issue's nonrating_issue_description to nil" do
           expect(subject).to eq nil
@@ -839,8 +878,10 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
         end
       end
 
-      context "unidentified" do
-        let(:decision_review_created) { build(:decision_review_created, :eligible_rating_hlr_unidentified) }
+      context "rating unidentified" do
+        let(:decision_review_created) do
+          build(:decision_review_created, :eligible_rating_hlr_unidentified_veteran_claimant)
+        end
 
         it "sets the Request Issue's nonrating_issue_description to nil" do
           expect(subject).to eq nil


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-44945](https://jira.devops.va.gov/browse/APPEALS-44945)

# Description
As a developer, I must update `Builders::DecisionReviewCreated::RequestIssueBuilder` to change how it's handling unidentified nonrating issues.

Currently when an issue is unidentified nonrating, a corresponding RequestIssue is built out with `is_unidentified: true` and `unidentified_issue_text: not nil`. The issue with this is Caseflow treats all unidentified issues as if they're rating issues. To fix this issue, this PR updates the logic to keep `is_unidentified: false` and `unidentified_issue_text: nil` if the issue is unidentified nonrating, and instead, they will be handled as if they are identified nonrating.

This PR also ensures unidentified rating, identified nonrating, and identified rating issues maintain existing functionality.

Additional unit tests were added to `end_product_establishment_builder_spec.rb` to maintain 100% code coverage.

## Acceptance Criteria
- [x] Unidentified nonrating issues should be handled as if they are identified nonrating issues
- [x] Unidentified rating issues maintain existing functionality
- [x] Identified nonrating issues maintain existing functionality
- [x] Identified rating issues maintain existing functionality
- [x] Additional unit tests added to `end_product_establishment_builder_spec.rb` to bump code coverage to 100% 

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
- [Test Steps](https://jira.devops.va.gov/browse/APPEALS-45268)
- [Test Execution](https://jira.devops.va.gov/browse/APPEALS-45271)
- [XRAY](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-45271&testIssueKey=APPEALS-45268)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added