### PR TITLE
DecisionReviewUpdatedEventProcessingJob and spec

### DIFF
--- a/app/jobs/decision_review_updated_event_processing_job.rb
+++ b/app/jobs/decision_review_updated_event_processing_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DecisionReviewUpdatedEventProcessingJob < BaseEventProcessingJob
+  queue_as :low_priority
+end

--- a/spec/jobs/decision_review_updated_event_processing_job_spec.rb
+++ b/spec/jobs/decision_review_updated_event_processing_job_spec.rb
@@ -25,10 +25,13 @@ RSpec.describe DecisionReviewUpdatedEventProcessingJob, type: :job do
     end
 
     it "logs the error" do
+      job_name = /\[DecisionReviewUpdatedEventProcessingJob\]/
+      error_message = /An error has occured while processing a job for the event with event_id/
+
       expect { described_class.perform_now(event) }.to raise_error(StandardError, "test error")
       expect(Rails.logger)
         .to have_received(:error)
-        .with(/An error has occured while processing a job for the event with event_id/)
+        .with(/#{job_name} #{error_message}/)
     end
   end
 

--- a/spec/jobs/decision_review_updated_event_processing_job_spec.rb
+++ b/spec/jobs/decision_review_updated_event_processing_job_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe DecisionReviewUpdatedEventProcessingJob, type: :job do
+  include ActiveJob::TestHelper
+  let!(:event) { create(:event) }
+
+  describe "#perform_now(event)" do
+    subject { DecisionReviewUpdatedEventProcessingJob.perform_now(event) }
+
+    before do
+      allow(event).to receive(:process!)
+    end
+
+    it "calls DecisionReviewUpdatedEventProcessingJob.process!(event) immediately and does not raise an error" do
+      expect { subject }.not_to raise_error
+    end
+  end
+
+  context "when an error occurs" do
+    let(:error) { StandardError.new("test error") }
+
+    before do
+      allow(event).to receive(:process!).and_raise(error)
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "logs the error" do
+      expect { described_class.perform_now(event) }.to raise_error(StandardError, "test error")
+      expect(Rails.logger)
+        .to have_received(:error)
+        .with(/An error has occured while processing a job for the event with event_id/)
+    end
+  end
+
+  describe "#perform_later(event)" do
+    subject { DecisionReviewUpdatedEventProcessingJob.perform_later(event) }
+
+    it "enqueues the job with the event as an argument" do
+      ActiveJob::Base.queue_adapter = :test
+      expect { subject }
+        .to have_enqueued_job(DecisionReviewUpdatedEventProcessingJob)
+        .with(event)
+        .on_queue("appeals_consumer"\
+        "_development_low_priority")
+    end
+
+    it "does not raise an error" do
+      expect { subject }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-50298](https://jira.devops.va.gov/browse/APPEALS-50298)

# Description
Creates the DecisionReviewUpdatedEventProcessingJob which inherits from BaseEventProcessingJob but enqueues into the low priority queue.

Rspec test includes:
- `#perform_now`
- `#perform_later`
  - Enqueues into low priority queue
- When error occurs
  - Logs error message and ensures job name appears in message

## Value Statement:

As a developer, I need to create DecisionReviewUpdatedEventProcessingJob in order to process Decision Review Updated events.

## Acceptance Criteria
- [x] DecisionReviewUpdatedEventProcessingJob exists and inherits from BaseEventProcessingJob 
- [x] DecisionReviewUpdatedEventProcessingJob enqueues into Low Priority Queue

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [APPEALS-51311 Test Create DecisionReviewUpdatedEventProcessingJob](https://jira.devops.va.gov/browse/APPEALS-51311)
2. [APPEALS-51319 Ad-hoc execution for Test Create DecisionReviewUpdatedEventProcessingJob](https://jira.devops.va.gov/browse/APPEALS-51319)
3. [Execution Xray](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-51319&testIssueKey=APPEALS-51311)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added