### PR TITLE
Update default value for FILED_BY_VA_GOV to be NULL.

### DIFF
--- a/app/models/builders/decision_review_created/claim_review_builder.rb
+++ b/app/models/builders/decision_review_created/claim_review_builder.rb
@@ -5,7 +5,7 @@ class Builders::DecisionReviewCreated::ClaimReviewBuilder
   include DecisionReview::ModelBuilderHelper
   attr_reader :claim_review, :decision_review_model
 
-  FILED_BY_VA_GOV = false
+  FILED_BY_VA_GOV = nil
 
   def self.build(decision_review_model)
     builder = new(decision_review_model)

--- a/spec/models/builders/decision_review_created/claim_review_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/claim_review_builder_spec.rb
@@ -65,8 +65,9 @@ describe Builders::DecisionReviewCreated::ClaimReviewBuilder do
 
   describe "#assign_filed_by_va_gov" do
     subject { builder.send(:assign_filed_by_va_gov) }
-    it "always assigns claim_review's filed_by_va_gov to false" do
+    it "always assigns claim_review's filed_by_va_gov to nil" do
       expect(subject).to eq(Builders::DecisionReviewCreated::ClaimReviewBuilder::FILED_BY_VA_GOV)
+      expect(subject).to eq(nil)
     end
   end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-55038](https://jira.devops.va.gov/browse/APPEALS-55038)

# Description
The Decision Review Created event does not indicate whether or not an intake was filed by va.gov.  Currently, the filed_by_va_gov attribute defaults to false.  The filed_by_va_gov value assigned by the appeals-consumer will need to be updated to nil to properly indicate that it is unknown whether the intake was filed by va.gov.

## Acceptance Criteria

- [x] FILED_BY_VA_GOV constant within the Builders::DecisionReviewCreated::ClaimReviewBuilder class has been assigned to value of nil.
- [x] All Decision Review Created Events that are consumed and posted to Caseflow result in a null value for the FILED_BY_VA_GOV field of HigherLevelReviews & Supplemental Claims.  
- [x] Caseflow UI functionality/behavior remains unchanged after event has been processed and records posted to Caseflow.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [TEST PLAN - APPEALS-56611](https://jira.devops.va.gov/browse/APPEALS-56611)
2. [TEST Exec - APPEALS-56612](https://jira.devops.va.gov/browse/APPEALS-56612)
3. [TEST XRay - APPEALS-56611](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-56612&testIssueKey=APPEALS-56611)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
