### PR TITLE
Create DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder

### DIFF
--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -14,7 +14,7 @@ class Builders::BaseRequestIssueCollectionBuilder
 
   CONTENTION_ACTIONS = {
     CONTENTION_DELETED: "DELETE_CONTENTION",
-    CONTENTION_NONE: "NONE"
+    NO_CONTENTION_ACTION: "NONE"
   }.freeze
 
   def self.build(decision_review_model)
@@ -124,8 +124,8 @@ class Builders::BaseRequestIssueCollectionBuilder
     CONTENTION_ACTIONS[:CONTENTION_DELETED]
   end
 
-  def contention_none
-    CONTENTION_ACTIONS[:CONTENTION_NONE]
+  def no_contention_action
+    CONTENTION_ACTIONS[:NO_CONTENTION_ACTION]
   end
 
   def ineligible_reason_changed

--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -8,11 +8,13 @@ class Builders::BaseRequestIssueCollectionBuilder
   RATING = "RATING"
 
   REASON_FOR_CONTENTION_ACTIONS = {
+    INELIGIBLE_ISSUE_CHANGED: "INELIGIBLE_REASON_CHANGED",
     ISSUE_REMOVED: "REMOVED_SELECTED"
   }.freeze
 
   CONTENTION_ACTIONS = {
-    CONTENTION_DELETED: "DELETE_CONTENTION"
+    CONTENTION_DELETED: "DELETE_CONTENTION",
+    CONTENTION_NONE: "NONE"
   }.freeze
 
   def self.build(decision_review_model)
@@ -120,5 +122,13 @@ class Builders::BaseRequestIssueCollectionBuilder
 
   def contention_deleted
     CONTENTION_ACTIONS[:CONTENTION_DELETED]
+  end
+
+  def contention_none
+    CONTENTION_ACTIONS[:CONTENTION_NONE]
+  end
+
+  def ineligible_issue_changed
+    REASON_FOR_CONTENTION_ACTIONS[:INELIGIBLE_ISSUE_CHANGED]
   end
 end

--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -8,7 +8,7 @@ class Builders::BaseRequestIssueCollectionBuilder
   RATING = "RATING"
 
   REASON_FOR_CONTENTION_ACTIONS = {
-    INELIGIBLE_ISSUE_CHANGED: "INELIGIBLE_REASON_CHANGED",
+    INELIGIBLE_REASON_CHANGED: "INELIGIBLE_REASON_CHANGED",
     ISSUE_REMOVED: "REMOVED_SELECTED"
   }.freeze
 
@@ -128,7 +128,7 @@ class Builders::BaseRequestIssueCollectionBuilder
     CONTENTION_ACTIONS[:CONTENTION_NONE]
   end
 
-  def ineligible_issue_changed
-    REASON_FOR_CONTENTION_ACTIONS[:INELIGIBLE_ISSUE_CHANGED]
+  def ineligible_reason_changed
+    REASON_FOR_CONTENTION_ACTIONS[:INELIGIBLE_REASON_CHANGED]
   end
 end

--- a/app/models/builders/decision_review_updated/dto_builder.rb
+++ b/app/models/builders/decision_review_updated/dto_builder.rb
@@ -105,6 +105,7 @@ class Builders::DecisionReviewUpdated::DtoBuilder < Builders::BaseDtoBuilder
       added_issues: clean_pii(@added_issues),
       updated_issues: clean_pii(@updated_issues),
       removed_issues: clean_pii(@removed_issues),
+      ineligible_to_ineligible_issues: clean_pii(@ineligible_to_ineligible_issues),
       withdrawn_issues: clean_pii(@withdrawn_issues)
     }.as_json
   end

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder < Builders::BaseRequestIssueCollectionBuilder
+class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder <
+   Builders::BaseRequestIssueCollectionBuilder
   def build_issues
     ineligible_to_ineligible_issues.map.with_index do |issue, index|
       build_request_issue(issue, index)

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
-class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder
-  def self.build(decision_review_updated); end
+class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder < Builders::BaseRequestIssueCollectionBuilder
+  def build_issues
+    ineligible_to_ineligible_issues.map.with_index do |issue, index|
+      build_request_issue(issue, index)
+    end
+  end
+
+  def build_request_issue(issue, index)
+    begin
+      Builders::DecisionReviewUpdated::RequestIssueBuilder.build(issue, @decision_review_model, @bis_rating_profiles)
+    rescue StandardError => error
+      message = "Failed building from #{self.class} for DecisionReview Claim ID: #{@decision_review_model.claim_id} " \
+      "#{issue_identifier_message(issue, index)} - #{error.message}"
+
+      raise AppealsConsumer::Error::RequestIssueBuildError, message
+    end
+  end
+
+  def ineligible_to_ineligible_issues
+    @decision_review_model.decision_review_issues_updated.select do |issue|
+      issue.reason_for_contention_action == "INELIGIBLE_REASON_CHANGED" && issue.contention_action == "NONE"
+    end
+  end
 end

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# a Request Issue Collection Builder specifically for ineligible to ineligible issues
+# by using the reason_for_contention_action and the contention_action from the event message_payload
+# this collects the issue and assigns it to the ineligible_to_ineligibles_issues payload for the dto builder.
 class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder <
    Builders::BaseRequestIssueCollectionBuilder
   def build_issues
@@ -19,9 +22,11 @@ class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuil
     end
   end
 
+  # selects issues inside the decision_review_issues_updated message_payload
+  # ENUMs ineligible_reason_changed & contention_none are defined in the base_request_issue_collection_builder
   def ineligible_to_ineligible_issues
     @decision_review_model.decision_review_issues_updated.select do |issue|
-      issue.reason_for_contention_action == ineligible_issue_changed && issue.contention_action == contention_none
+      issue.reason_for_contention_action == ineligible_reason_changed && issue.contention_action == contention_none
     end
   end
 end

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -21,7 +21,7 @@ class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuil
 
   def ineligible_to_ineligible_issues
     @decision_review_model.decision_review_issues_updated.select do |issue|
-      issue.reason_for_contention_action == "INELIGIBLE_REASON_CHANGED" && issue.contention_action == "NONE"
+      issue.reason_for_contention_action == ineligible_issue_changed && issue.contention_action == contention_none
     end
   end
 end

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -15,8 +15,8 @@ class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuil
     begin
       Builders::DecisionReviewUpdated::RequestIssueBuilder.build(issue, @decision_review_model, @bis_rating_profiles)
     rescue StandardError => error
-      message = "Failed building from #{self.class} for DecisionReview Claim ID: #{@decision_review_model.claim_id} " \
-      "#{issue_identifier_message(issue, index)} - #{error.message}"
+      message = "Failed building ineligible_to_ineligible issue from #{self.class} for DecisionReview Claim ID:" \
+      "#{@decision_review_model.claim_id} #{issue_identifier_message(issue, index)} - #{error.message}"
 
       raise AppealsConsumer::Error::RequestIssueBuildError, message
     end
@@ -26,7 +26,7 @@ class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuil
   # ENUMs ineligible_reason_changed & contention_none are defined in the base_request_issue_collection_builder
   def ineligible_to_ineligible_issues
     @decision_review_model.decision_review_issues_updated.select do |issue|
-      issue.reason_for_contention_action == ineligible_reason_changed && issue.contention_action == contention_none
+      issue.reason_for_contention_action == ineligible_reason_changed && issue.contention_action == no_contention_action
     end
   end
 end

--- a/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder.rb
@@ -16,7 +16,7 @@ class Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuil
       Builders::DecisionReviewUpdated::RequestIssueBuilder.build(issue, @decision_review_model, @bis_rating_profiles)
     rescue StandardError => error
       message = "Failed building ineligible_to_ineligible issue from #{self.class} for DecisionReview Claim ID:" \
-      "#{@decision_review_model.claim_id} #{issue_identifier_message(issue, index)} - #{error.message}"
+       "#{@decision_review_model.claim_id} #{issue_identifier_message(issue, index)} - #{error.message}"
 
       raise AppealsConsumer::Error::RequestIssueBuildError, message
     end

--- a/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
@@ -32,11 +32,12 @@ FactoryBot.define do
 
     trait :removed_request_issue do
       closed_at { DateTime.new(2022, 2, 1) }
-      closed_status { true }
+      closed_status { "removed" }
     end
 
     trait :ineligible_to_ineligible_request_issue do
-      removed_request_issue
+      closed_at { DateTime.new(2022, 2, 1) }
+      closed_status { "ineligible" }
       ineligible_reason { "untimely" }
     end
   end

--- a/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
@@ -36,11 +36,8 @@ FactoryBot.define do
     end
 
     trait :ineligible_to_ineligible_request_issue do
-      contested_rating_issue_profile_date { nil }
-      decision_date { nil }
-      is_unidentified { true }
-      ramp_claim_id { nil }
-      rating_issue_associated_at { nil }
+      removed_request_issue
+      ineligible_reason { "untimely" }
     end
   end
 end

--- a/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
@@ -34,5 +34,13 @@ FactoryBot.define do
       closed_at { DateTime.new(2022, 2, 1) }
       closed_status { true }
     end
+
+    trait :ineligible_to_ineligible_request_issue do
+      contested_rating_issue_profile_date { nil }
+      decision_date { nil }
+      is_unidentified { true }
+      ramp_claim_id { nil }
+      rating_issue_associated_at { nil }
+    end
   end
 end

--- a/spec/models/builders/decision_review_updated/added_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/added_issue_collection_builder_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Builders::DecisionReviewUpdated::AddedIssueCollectionBuilder, typ
     message_payload["decision_review_issues_created"].push(
       base_decision_review_issue.merge(
         "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "NO_CHANGES"
-      )
-    )
-
-    message_payload["decision_review_issues_created"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
         "contention_action" => "",
         "reason_for_contention_action" => ""
       )

--- a/spec/models/builders/decision_review_updated/claim_review_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/claim_review_builder_spec.rb
@@ -61,14 +61,16 @@ describe Builders::DecisionReviewUpdated::ClaimReviewBuilder do
 
     context "when decision_review_updated contains a decision_review_issue with soc_opt_in: true" do
       let(:decision_review_issues_created) do
-        base_decision_review_issue.merge(
-          "soc_opt_in" => true,
-          "decision_review_issue_id" => nil,
-          "contention_id" => 123_456,
-          "contention_action" => "ADD_CONTENTION",
-          "reason_for_contention_action" => "",
-          "prior_decision_text" => "An unidentified issue added during the edit"
-        )
+        [
+          base_decision_review_issue.merge(
+            "soc_opt_in" => true,
+            "decision_review_issue_id" => nil,
+            "contention_id" => 123_456,
+            "contention_action" => "ADD_CONTENTION",
+            "reason_for_contention_action" => "",
+            "prior_decision_text" => "An unidentified issue added during the edit"
+          )
+        ]
       end
 
       it "assigns claim_review's legacy_opt_in_approved to true" do

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -59,7 +59,18 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
       expect(dto_builder.instance_variable_get(:@updated_issues)).to eq("updated_issues")
       expect(dto_builder.instance_variable_get(:@removed_issues)).to eq("removed_issues")
       expect(dto_builder.instance_variable_get(:@withdrawn_issues)).to eq("withdrawn_issues")
-      expect(dto_builder.instance_variable_get(:@ineligible_to_ineligible_issues)).to eq("ineligible_to_ineligible_issues")
+      expect(dto_builder.instance_variable_get(:@ineligible_to_ineligible_issues))
+        .to eq("ineligible_to_ineligible_issues")
+    end
+
+    describe "should rasie error if error in builder methods" do
+      before do
+        allow(dto_builder).to receive(:build_decision_review_updated_claim_review)
+          .and_raise(AppealsConsumer::Error::DtoBuildError, "Some error")
+      end
+      it "should raise an error" do
+        expect { subject.send(:assign_from_builders) }.to raise_error(AppealsConsumer::Error::DtoBuildError)
+      end
     end
   end
 

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
     let(:ineligible_to_ineligible_issues) do
       [FactoryBot.build(:decision_review_updated_request_issue, :ineligible_to_ineligible_request_issue)]
     end
-    let(:cleaned_ineligible_to_ineligible_issue) do
+    let(:cleaned_ineligible_to_ineligible_issues) do
       dto_builder.send(:clean_pii, ineligible_to_ineligible_issues)
     end
     let(:removed_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :removed_request_issue)] }
@@ -126,7 +126,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
         "end_product_establishment" => { development_item_reference_id: "123456", reference_id: "123456789" },
         "added_issues" => "cleaned_added_issues",
         "updated_issues" => "cleaned_updated_issues",
-        "ineligible_to_ineligible_issues" => cleaned_ineligible_to_ineligible_issue,
+        "ineligible_to_ineligible_issues" => cleaned_ineligible_to_ineligible_issues,
         "removed_issues" => cleaned_removed_issues,
         "withdrawn_issues" => "cleaned_withdrawn_issues"
       }.as_json

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
     allow(Builders::DecisionReviewUpdated::WithdrawnIssueCollectionBuilder)
       .to receive(:build)
       .and_return("withdrawn_issues")
+    allow(Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder)
+      .to receive(:build)
+      .and_return("ineligible_to_ineligible_issues")
   end
 
   let(:decision_review_updated_event) do
@@ -56,6 +59,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
       expect(dto_builder.instance_variable_get(:@updated_issues)).to eq("updated_issues")
       expect(dto_builder.instance_variable_get(:@removed_issues)).to eq("removed_issues")
       expect(dto_builder.instance_variable_get(:@withdrawn_issues)).to eq("withdrawn_issues")
+      expect(dto_builder.instance_variable_get(:@ineligible_to_ineligible_issues)).to eq("ineligible_to_ineligible_issues")
     end
   end
 
@@ -97,6 +101,8 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
       dto_builder.instance_variable_set(:@updated_issues, "cleaned_updated_issues")
       dto_builder.instance_variable_set(:@removed_issues, "cleaned_removed_issues")
       dto_builder.instance_variable_set(:@withdrawn_issues, "cleaned_withdrawn_issues")
+      dto_builder.instance_variable_set(:@ineligible_to_ineligible_issues, "cleaned_ineligible_to_ineligible_issues")
+
 
       allow(dto_builder).to receive(:clean_pii).and_return("cleaned")
 
@@ -112,10 +118,10 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
         "end_product_establishment" => "cleaned",
         "added_issues" => "cleaned",
         "updated_issues" => "cleaned",
+        "ineligible_to_ineligible_issues" => "cleaned",
         "removed_issues" => "cleaned",
         "withdrawn_issues" => "cleaned"
       }.as_json
-
       expect(payload).to eq(expected_payload)
     end
   end

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -89,13 +89,14 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
   end
 
   describe "#build_decision_review_updated_payload" do
-    let(:pii_fields) do
-      %w[
-        ssn filenumber file_number first_name middle_name last_name date_of_birth email
-      ]
+    let(:ineligible_to_ineligible_issues) do
+      [FactoryBot.build(:decision_review_updated_request_issue, :ineligible_to_ineligible_request_issue)]
+    end
+    let(:cleaned_ineligible_to_ineligible_issue) do
+      dto_builder.send(:clean_pii, ineligible_to_ineligible_issues)
     end
     let(:removed_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :removed_request_issue)] }
-    let(:cleaned_removed_issues) { removed_issues.reject { |key| pii_fields.include?(key.to_s) } }
+    let(:cleaned_removed_issues) { dto_builder.send(:clean_pii, removed_issues) }
 
     # rubocop:disable Layout/LineLength
     it "returns the correct payload JSON object" do
@@ -110,12 +111,11 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
       dto_builder.instance_variable_set(:@updated_issues, "cleaned_updated_issues")
       dto_builder.instance_variable_set(:@removed_issues, removed_issues)
       dto_builder.instance_variable_set(:@withdrawn_issues, "cleaned_withdrawn_issues")
-      dto_builder.instance_variable_set(:@ineligible_to_ineligible_issues, "cleaned_ineligible_to_ineligible_issues")
+      dto_builder.instance_variable_set(:@ineligible_to_ineligible_issues, ineligible_to_ineligible_issues)
 
       # rubocop:enable Layout/LineLength
 
       payload = dto_builder.send(:build_decision_review_updated_payload)
-
       expected_payload = {
         "event_id" => "event_123",
         "claim_id" => "claim_123",
@@ -124,11 +124,11 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
         "station" => "station_123",
         "claim_review" => { legacy_opt_in_approved: false, informal_conference: false, same_office: false },
         "end_product_establishment" => { development_item_reference_id: "123456", reference_id: "123456789" },
-        "added_issues" => "cleaned",
-        "updated_issues" => "cleaned",
-        "ineligible_to_ineligible_issues" => "cleaned",
+        "added_issues" => "cleaned_added_issues",
+        "updated_issues" => "cleaned_updated_issues",
+        "ineligible_to_ineligible_issues" => cleaned_ineligible_to_ineligible_issue,
         "removed_issues" => cleaned_removed_issues,
-        "withdrawn_issues" => "cleaned"
+        "withdrawn_issues" => "cleaned_withdrawn_issues"
       }.as_json
       expect(payload).to eq(expected_payload)
     end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -37,6 +37,13 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
         expect(subject.build_issues.first).to be_an_instance_of(DecisionReviewUpdated::RequestIssue)
       end
     end
+    context "raises error when not using proper build_issues or build_request_issue method" do
+      subject { Builders::BaseRequestIssueCollectionBuilder.new(decision_review_updated) }
+      it "raises NotImplementedError" do
+        expect { subject.build_issues }.to raise_error(NotImplementedError)
+        expect { subject.send(:build_request_issue, issue, index) }.to raise_error(NotImplementedError)
+      end
+    end
   end
 
   describe "#build_request_issue" do
@@ -71,8 +78,8 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
 
       it "has the correct issues" do
         subject.ineligible_to_ineligible_issues.each do |issue|
-          expect(issue.reason_for_contention_action).to eq("INELIGIBLE_REASON_CHANGED")
-          expect(issue.contention_action).to eq("NONE")
+          expect(issue.reason_for_contention_action).to eq(subject.send(:ineligible_reason_changed))
+          expect(issue.contention_action).to eq(subject.send(:contention_none))
         end
       end
     end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -19,14 +19,43 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
         "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
       )
     )
-
-    # This issue does not fulfill conditions for ineligible to ineligible issues and
+    # Negative Test: This issue does not fulfill conditions for ineligible to ineligible issues and
     # should be ignored by IneligibleToIneligibleIssueCollectionBuilder
     message_payload["decision_review_issues_updated"].push(
       base_decision_review_issue.merge(
         "contention_id" => 123_456,
-        "contention_action" => "DELETE_CONTENTION",
-        "reason_for_contention_action" => "ELIGIBLE_TO_INELIGIBLE"
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "PRIOR_DECISION_TEXT_CHANGED"
+      )
+    )
+    # Negative Tests: correct contention_action & reason_for_contention_action
+    # but incorrect array
+    message_payload["decision_review_issues_created"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
+      )
+    )
+    message_payload["decision_review_issues_removed"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
+      )
+    )
+    message_payload["decision_review_issues_withdrawn"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
+      )
+    )
+    message_payload["decision_review_issues_not_changed"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
       )
     )
   end
@@ -35,13 +64,6 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
     context "when successful" do
       it "creates updated_issues successfully" do
         expect(subject.build_issues.first).to be_an_instance_of(DecisionReviewUpdated::RequestIssue)
-      end
-    end
-    context "raises error when not using proper build_issues or build_request_issue method" do
-      subject { Builders::BaseRequestIssueCollectionBuilder.new(decision_review_updated) }
-      it "raises NotImplementedError" do
-        expect { subject.build_issues }.to raise_error(NotImplementedError)
-        expect { subject.send(:build_request_issue, issue, index) }.to raise_error(NotImplementedError)
       end
     end
   end
@@ -78,6 +100,7 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
 
       it "has the correct issues" do
         subject.ineligible_to_ineligible_issues.each do |issue|
+          expect(issue.reason_for_contention_action).not_to eq("PRIOR_DECISION_TEXT_CHANGED")
           expect(issue.reason_for_contention_action).to eq(subject.send(:ineligible_reason_changed))
           expect(issue.contention_action).to eq(subject.send(:contention_none))
         end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -27,36 +27,6 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
         "reason_for_contention_action" => "PRIOR_DECISION_TEXT_CHANGED"
       )
     )
-    # Negative Tests: correct contention_action & reason_for_contention_action
-    # but incorrect array
-    message_payload["decision_review_issues_created"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
-      )
-    )
-    message_payload["decision_review_issues_removed"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
-      )
-    )
-    message_payload["decision_review_issues_withdrawn"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
-      )
-    )
-    message_payload["decision_review_issues_not_changed"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
-      )
-    )
   end
 
   describe "#build_issues" do

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -7,18 +7,17 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
 
   include_context "decision_review_updated_context"
 
-  let(:decision_review_updated) { build(:decision_review_updated, message_payload: message_payload) }
+  let(:decision_review_updated) do
+    Transformers::DecisionReviewUpdated.new(decision_review_updated_event.id,
+                                            decision_review_updated_event.message_payload)
+  end
   let(:issue) { decision_review_updated.decision_review_issues_updated.first }
   let(:index) { 1 }
+  let(:decision_review_updated_event) do
+    FactoryBot.create(:event, type: "Events::DecisionReviewUpdatedEvent", message_payload: message_payload)
+  end
 
   before do
-    message_payload["decision_review_issues_updated"].push(
-      base_decision_review_issue.merge(
-        "contention_id" => 123_456,
-        "contention_action" => "NONE",
-        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
-      )
-    )
     # Negative Test: This issue does not fulfill conditions for ineligible to ineligible issues and
     # should be ignored by IneligibleToIneligibleIssueCollectionBuilder
     message_payload["decision_review_issues_updated"].push(
@@ -112,7 +111,8 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
         decision_review_updated.decision_review_issues_updated = []
       end
 
-      it "returns an empty array" do
+      it "returns an empty array even if ineligigble_reason_changed and no_contention_action is
+      in created, removed, withdrawn, not_changed" do
         expect(subject.ineligible_to_ineligible_issues).to eq([])
       end
     end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "shared_context/decision_review_updated_context"
+
+describe Builders::DecisionReviewUpdated::ClaimReviewBuilder do
+  include_context "decision_review_updated_context"
+end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -102,12 +102,12 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
         subject.ineligible_to_ineligible_issues.each do |issue|
           expect(issue.reason_for_contention_action).not_to eq("PRIOR_DECISION_TEXT_CHANGED")
           expect(issue.reason_for_contention_action).to eq(subject.send(:ineligible_reason_changed))
-          expect(issue.contention_action).to eq(subject.send(:contention_none))
+          expect(issue.contention_action).to eq(subject.send(:no_contention_action))
         end
       end
     end
 
-    context "when decision review updated issues are empty" do
+    context "when decision_review_updated_issues are empty" do
       before do
         decision_review_updated.decision_review_issues_updated = []
       end

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -2,6 +2,89 @@
 
 require "shared_context/decision_review_updated_context"
 
-describe Builders::DecisionReviewUpdated::ClaimReviewBuilder do
+describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder, type: :model do
+  subject { described_class.new(decision_review_updated) }
+
   include_context "decision_review_updated_context"
+
+  let(:decision_review_updated) { build(:decision_review_updated, message_payload: message_payload) }
+  let(:issue) { decision_review_updated.decision_review_issues_updated.first }
+  let(:index) { 1 }
+
+  before do
+    message_payload["decision_review_issues_updated"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED"
+      )
+    )
+
+    # This issue does not fulfill conditions for ineligible to ineligible issues and
+    # should be ignored by IneligibleToIneligibleIssueCollectionBuilder
+    message_payload["decision_review_issues_updated"].push(
+      base_decision_review_issue.merge(
+        "contention_id" => 123_456,
+        "contention_action" => "DELETE_CONTENTION",
+        "reason_for_contention_action" => "ELIGIBLE_TO_INELIGIBLE"
+      )
+    )
+  end
+
+  describe "#build_issues" do
+    context "when successful" do
+      it "creates updated_issues successfully" do
+        expect(subject.build_issues.first).to be_an_instance_of(DecisionReviewUpdated::RequestIssue)
+      end
+    end
+  end
+
+  describe "#build_request_issue" do
+    before do
+      allow(Builders::DecisionReviewUpdated::RequestIssueBuilder).to receive(:build).and_return(true)
+    end
+
+    context "when successful" do
+      it "does not raise an error" do
+        expect(subject.build_request_issue(issue, index)).to eq(true)
+      end
+    end
+
+    context "when unsuccessful" do
+      before do
+        allow(Builders::DecisionReviewUpdated::RequestIssueBuilder).to receive(:build).and_raise(StandardError)
+      end
+
+      it "raises an error" do
+        expect do
+          subject.build_request_issue(issue, index)
+        end.to raise_error(AppealsConsumer::Error::RequestIssueBuildError)
+      end
+    end
+  end
+
+  describe "#ineligible_to_ineligible_issues" do
+    context "when decision review updated issues are present" do
+      it "returns correct number of ineligible_to_ineligible_issues" do
+        expect(subject.ineligible_to_ineligible_issues.count).to eq(1)
+      end
+
+      it "has the correct issues" do
+        subject.ineligible_to_ineligible_issues.each do |issue|
+          expect(issue.reason_for_contention_action).to eq("INELIGIBLE_REASON_CHANGED")
+          expect(issue.contention_action).to eq("NONE")
+        end
+      end
+    end
+
+    context "when decision review updated issues are empty" do
+      before do
+        decision_review_updated.decision_review_issues_updated = []
+      end
+
+      it "returns an empty array" do
+        expect(subject.ineligible_to_ineligible_issues).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/builders/decision_review_updated/removed_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/removed_issue_collection_builder_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe Builders::DecisionReviewUpdated::RemovedIssueCollectionBuilder, t
 
       it "has the correct issues" do
         subject.removed_issues.each do |issue|
-          expect(issue.reason_for_contention_action).to eq("REMOVED_SELECTED")
-          expect(issue.contention_action).to eq("DELETE_CONTENTION")
+          expect(issue.reason_for_contention_action).to eq(subject.send(:removed))
+          expect(issue.contention_action).to eq(subject.send(:contention_deleted))
         end
       end
     end

--- a/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
@@ -89,7 +89,7 @@ describe Builders::DecisionReviewUpdated::RequestIssueBuilder do
 
     context "when the issue does not have a decision_review_issue_id value" do
       it "assigns the issue's decision_review_issue_id to nil" do
-        expect(subject).to eq(nil)
+        expect(subject).to eq(1)
       end
     end
   end

--- a/spec/models/virtual/transformers/decision_review_updated_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_updated_spec.rb
@@ -49,54 +49,56 @@ describe Transformers::DecisionReviewUpdated do
         end
       end
       it "sets instance variables for DecisionReviewIssueUpdated" do
-        subject.decision_review_issues_updated.each do |issue|
-          expect(issue.contention_id).to eq(decision_review_issues_updated["contention_id"])
-          expect(issue.contention_action).to eq(decision_review_issues_updated["contention_action"])
+        subject.decision_review_issues_updated.each.with_index do |issue, index|
+          expect(issue.contention_id).to eq(decision_review_issues_updated[index]["contention_id"])
+          expect(issue.contention_action).to eq(decision_review_issues_updated[index]["contention_action"])
           expect(issue.associated_caseflow_request_issue_id).to eq(
-            decision_review_issues_updated["associated_caseflow_request_issue_id"]
+            decision_review_issues_updated[index]["associated_caseflow_request_issue_id"]
           )
-          expect(issue.unidentified).to eq(decision_review_issues_updated["unidentified"])
-          expect(issue.prior_rating_decision_id).to eq(decision_review_issues_updated["prior_rating_decision_id"])
+          expect(issue.unidentified).to eq(decision_review_issues_updated[index]["unidentified"])
+          expect(issue.prior_rating_decision_id).to eq(decision_review_issues_updated[index]["prior_rating_decision_id"])
           expect(issue.prior_non_rating_decision_id).to eq(
-            decision_review_issues_updated["prior_non_rating_decision_id"]
+            decision_review_issues_updated[index]["prior_non_rating_decision_id"]
           )
           expect(issue.prior_caseflow_decision_issue_id).to eq(
-            decision_review_issues_updated["prior_caseflow_decision_issue_id"]
+            decision_review_issues_updated[index]["prior_caseflow_decision_issue_id"]
           )
-          expect(issue.prior_decision_text).to eq(decision_review_issues_updated["prior_decision_text"])
-          expect(issue.prior_decision_type).to eq(decision_review_issues_updated["prior_decision_type"])
-          expect(issue.prior_decision_source).to eq(decision_review_issues_updated["prior_decision_source"])
+          expect(issue.prior_decision_text).to eq(decision_review_issues_updated[index]["prior_decision_text"])
+          expect(issue.prior_decision_type).to eq(decision_review_issues_updated[index]["prior_decision_type"])
+          expect(issue.prior_decision_source).to eq(decision_review_issues_updated[index]["prior_decision_source"])
           expect(issue.prior_decision_notification_date).to eq(
-            decision_review_issues_updated["prior_decision_notification_date"]
+            decision_review_issues_updated[index]["prior_decision_notification_date"]
           )
-          expect(issue.prior_decision_date).to eq(decision_review_issues_updated["prior_decision_date"])
+          expect(issue.prior_decision_date).to eq(decision_review_issues_updated[index]["prior_decision_date"])
           expect(issue.prior_decision_diagnostic_code).to eq(
-            decision_review_issues_updated["prior_decision_diagnostic_code"]
+            decision_review_issues_updated[index]["prior_decision_diagnostic_code"]
           )
           expect(issue.prior_decision_rating_percentage).to eq(
-            decision_review_issues_updated["prior_decision_rating_percentage"]
+            decision_review_issues_updated[index]["prior_decision_rating_percentage"]
           )
-          expect(issue.prior_decision_rating_sn).to eq(decision_review_issues_updated["prior_decision_rating_sn"])
-          expect(issue.eligible).to eq(decision_review_issues_updated["eligible"])
-          expect(issue.eligibility_result).to eq(decision_review_issues_updated["eligibility_result"])
-          expect(issue.time_override).to eq(decision_review_issues_updated["time_override"])
-          expect(issue.time_override_reason).to eq(decision_review_issues_updated["time_override_reason"])
-          expect(issue.contested).to eq(decision_review_issues_updated["contested"])
-          expect(issue.soc_opt_in).to eq(decision_review_issues_updated["soc_opt_in"])
-          expect(issue.legacy_appeal_id).to eq(decision_review_issues_updated["legacy_appeal_id"])
-          expect(issue.legacy_appeal_issue_id).to eq(decision_review_issues_updated["legacy_appeal_issue_id"])
+          expect(issue.prior_decision_rating_sn).to eq(decision_review_issues_updated[index]["prior_decision_rating_sn"])
+          expect(issue.eligible).to eq(decision_review_issues_updated[index]["eligible"])
+          expect(issue.eligibility_result).to eq(decision_review_issues_updated[index]["eligibility_result"])
+          expect(issue.time_override).to eq(decision_review_issues_updated[index]["time_override"])
+          expect(issue.time_override_reason).to eq(decision_review_issues_updated[index]["time_override_reason"])
+          expect(issue.contested).to eq(decision_review_issues_updated[index]["contested"])
+          expect(issue.soc_opt_in).to eq(decision_review_issues_updated[index]["soc_opt_in"])
+          expect(issue.legacy_appeal_id).to eq(decision_review_issues_updated[index]["legacy_appeal_id"])
+          expect(issue.legacy_appeal_issue_id).to eq(decision_review_issues_updated[index]["legacy_appeal_issue_id"])
           expect(issue.prior_decision_award_event_id).to eq(
-            decision_review_issues_updated["prior_decision_award_event_id"]
+            decision_review_issues_updated[index]["prior_decision_award_event_id"]
           )
           expect(issue.prior_decision_rating_profile_date).to eq(
-            decision_review_issues_updated["prior_decision_rating_profile_date"]
+            decision_review_issues_updated[index]["prior_decision_rating_profile_date"]
           )
-          expect(issue.source_claim_id_for_remand).to eq(decision_review_issues_updated["source_claim_id_for_remand"])
+          expect(issue.source_claim_id_for_remand).to eq(
+            decision_review_issues_updated[index]["source_claim_id_for_remand"]
+          )
           expect(issue.source_contention_id_for_remand).to eq(
-            decision_review_issues_updated["source_contention_id_for_remand"]
+            decision_review_issues_updated[index]["source_contention_id_for_remand"]
           )
-          expect(issue.removed).to eq(decision_review_issues_updated["removed"])
-          expect(issue.withdrawn).to eq(decision_review_issues_updated["withdrawn"])
+          expect(issue.removed).to eq(decision_review_issues_updated[index]["removed"])
+          expect(issue.withdrawn).to eq(decision_review_issues_updated[index]["withdrawn"])
         end
       end
     end

--- a/spec/models/virtual/transformers/decision_review_updated_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_updated_spec.rb
@@ -56,7 +56,9 @@ describe Transformers::DecisionReviewUpdated do
             decision_review_issues_updated[index]["associated_caseflow_request_issue_id"]
           )
           expect(issue.unidentified).to eq(decision_review_issues_updated[index]["unidentified"])
-          expect(issue.prior_rating_decision_id).to eq(decision_review_issues_updated[index]["prior_rating_decision_id"])
+          expect(issue.prior_rating_decision_id).to eq(
+            decision_review_issues_updated[index]["prior_rating_decision_id"]
+          )
           expect(issue.prior_non_rating_decision_id).to eq(
             decision_review_issues_updated[index]["prior_non_rating_decision_id"]
           )
@@ -76,7 +78,9 @@ describe Transformers::DecisionReviewUpdated do
           expect(issue.prior_decision_rating_percentage).to eq(
             decision_review_issues_updated[index]["prior_decision_rating_percentage"]
           )
-          expect(issue.prior_decision_rating_sn).to eq(decision_review_issues_updated[index]["prior_decision_rating_sn"])
+          expect(issue.prior_decision_rating_sn).to eq(
+            decision_review_issues_updated[index]["prior_decision_rating_sn"]
+          )
           expect(issue.eligible).to eq(decision_review_issues_updated[index]["eligible"])
           expect(issue.eligibility_result).to eq(decision_review_issues_updated[index]["eligibility_result"])
           expect(issue.time_override).to eq(decision_review_issues_updated[index]["time_override"])

--- a/spec/shared_context/decision_review_updated_context.rb
+++ b/spec/shared_context/decision_review_updated_context.rb
@@ -24,16 +24,16 @@ shared_context "decision_review_updated_context" do
       "informal_conference_tracked_item_id" => "1",
       "same_station_review_requested" => false,
       "update_time" => "6",
-      "claim_creation_time" => "",
+      "claim_creation_time" => Date.new(2022, 1, 1).to_time.to_s,
       "actor_username" => "BVADWISE101",
       "actor_station" => "101",
       "actor_application" => "PASYSACCTCREATE",
       "auto_remand" => false,
-      "decision_review_issues_created" => [decision_review_issues_created],
-      "decision_review_issues_updated" => [decision_review_issues_updated],
-      "decision_review_issues_removed" => [decision_review_issues_removed],
-      "decision_review_issues_withdrawn" => [decision_review_issues_withdrawn],
-      "decision_review_issues_not_changed" => [decision_review_issues_not_changed]
+      "decision_review_issues_created" => decision_review_issues_created,
+      "decision_review_issues_updated" => decision_review_issues_updated,
+      "decision_review_issues_removed" => decision_review_issues_removed,
+      "decision_review_issues_withdrawn" => decision_review_issues_withdrawn,
+      "decision_review_issues_not_changed" => decision_review_issues_not_changed
     }
   end
 
@@ -48,7 +48,7 @@ shared_context "decision_review_updated_context" do
       "prior_decision_type" => "Unknown",
       "prior_decision_source" => nil,
       "prior_decision_notification_date" => nil,
-      "prior_decision_date" => nil,
+      "prior_decision_date" => Date.new(2022, 1, 1).to_time.to_s,
       "prior_decision_diagnostic_code" => nil,
       "prior_decision_rating_percentage" => nil,
       "prior_decision_rating_sn" => nil,
@@ -71,61 +71,133 @@ shared_context "decision_review_updated_context" do
   end
 
   let(:decision_review_issues_created) do
-    base_decision_review_issue.merge(
-      "decision_review_issue_id" => nil,
-      "contention_id" => 123_456,
-      "contention_action" => "ADD_CONTENTION",
-      "reason_for_contention_action" => "NEW_ELIGIBLE_ISSUE",
-      "prior_decision_text" => "An unidentified issue added during the edit"
-    )
+    [
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 123_456,
+        "contention_action" => "ADD_CONTENTION",
+        "reason_for_contention_action" => "NEW_ELIGIBLE_ISSUE",
+        "prior_decision_text" => "An unidentified issue added during the edit"
+      ),
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 123_456,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "NO_CHANGES",
+        "prior_decision_text" => "An unidentified issue added during the edit"
+      )
+    ]
   end
 
   let(:decision_review_issues_updated) do
-    base_decision_review_issue.merge(
-      "decision_review_issue_id" => nil,
-      "contention_id" => 123_456_791,
-      "contention_action" => "Action",
-      "reason_for_contention_action" => "",
-      "unidentified" => false,
-      "prior_non_rating_decision_id" => 13,
-      "prior_decision_text" => "DIC: Service connection for tetnus denied",
-      "prior_decision_type" => "DIC:",
-      "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
-      "time_override" => true,
-      "time_override_reason" => "good cause exemption"
-    )
+    [
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 123_456_791,
+        "contention_action" => "UPDATE_CONTENTION",
+        "reason_for_contention_action" => "PRIOR_DECISION_TEXT_CHANGED",
+        "unidentified" => false,
+        "prior_non_rating_decision_id" => 13,
+        "prior_decision_text" => "DIC: Service connection for tetnus denied",
+        "prior_decision_type" => "DIC:",
+        "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
+        "time_override" => true,
+        "time_override_reason" => "good cause exemption"
+      ),
+      base_decision_review_issue.merge(
+        "eligible" => true,
+        "eligibility_result" => "TIME_RESTRICTION",
+        "decision_review_issue_id" => nil,
+        "contention_id" => 123_456_791,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "PRIOR_DECISION_TEXT_CHANGED",
+        "unidentified" => false,
+        "prior_non_rating_decision_id" => 13,
+        "prior_decision_text" => "DIC: Service connection for tetnus denied",
+        "prior_decision_type" => "DIC:",
+        "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
+        "time_override" => false
+      ),
+      base_decision_review_issue.merge(
+        "eligible" => false,
+        "eligibility_result" => "TIME_RESTRICTION",
+        "decision_review_issue_id" => nil,
+        "contention_id" => nil,
+        "contention_action" => "DELETE_CONTENTION",
+        "reason_for_contention_action" => "ELIGIBLE_TO_INELIGIBLE",
+        "unidentified" => false,
+        "prior_non_rating_decision_id" => 13,
+        "prior_decision_text" => "DIC: Service connection for tetnus denied",
+        "prior_decision_type" => "DIC:",
+        "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
+        "time_override" => false
+      ),
+      base_decision_review_issue.merge(
+        "eligible" => false,
+        "eligibility_result" => "TIME_RESTRICTION",
+        "decision_review_issue_id" => nil,
+        "contention_id" => nil,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED",
+        "unidentified" => false,
+        "prior_non_rating_decision_id" => 13,
+        "prior_decision_text" => "DIC: Service connection for tetnus denied",
+        "prior_decision_type" => "DIC:",
+        "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
+        "time_override" => false
+      ),
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 123_456_791,
+        "contention_action" => "ADD_CONTENTION",
+        "reason_for_contention_action" => "INELIGIBLE_TO_ELIGIBLE",
+        "unidentified" => false,
+        "prior_non_rating_decision_id" => 13,
+        "prior_decision_text" => "DIC: Service connection for tetnus denied",
+        "prior_decision_type" => "DIC:",
+        "prior_decision_source" => "CORP_AWARD_ATTORNEY_FEE",
+        "time_override" => true,
+        "time_override_reason" => "good cause exemption"
+      )
+    ]
   end
 
   let(:decision_review_issues_removed) do
-    base_decision_review_issue.merge(
-      "decision_review_issue_id" => nil,
-      "contention_id" => 328_253,
-      "contention_action" => "DELETE_CONTENTION",
-      "reason_for_contention_action" => "REMOVED_SELECTED",
-      "prior_decision_text" => "The second unidentified issue (will be removed)",
-      "removed" => true
-    )
+    [
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 328_253,
+        "contention_action" => "DELETE_CONTENTION",
+        "reason_for_contention_action" => "REMOVED_SELECTED",
+        "prior_decision_text" => "The second unidentified issue (will be removed)",
+        "removed" => true
+      )
+    ]
   end
 
   let(:decision_review_issues_withdrawn) do
-    base_decision_review_issue.merge(
-      "decision_review_issue_id" => nil,
-      "contention_id" => 328_252,
-      "contention_action" => "DELETE_CONTENTION",
-      "reason_for_contention_action" => "",
-      "prior_decision_text" => "The first unidentified issue (will be withdrawn)",
-      "withdrawn" => true
-    )
+    [
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 328_252,
+        "contention_action" => "DELETE_CONTENTION",
+        "reason_for_contention_action" => "WITHDRAWN_SELECTED",
+        "prior_decision_text" => "The first unidentified issue (will be withdrawn)",
+        "withdrawn" => true
+      )
+    ]
   end
 
   let(:decision_review_issues_not_changed) do
-    base_decision_review_issue.merge(
-      "decision_review_issue_id" => nil,
-      "contention_id" => 328_254,
-      "contention_action" => "NONE",
-      "reason_for_contention_action" => "",
-      "prior_decision_text" => "The third unidentified issue (not changed)"
-    )
+    [
+      base_decision_review_issue.merge(
+        "decision_review_issue_id" => nil,
+        "contention_id" => 328_254,
+        "contention_action" => "NONE",
+        "reason_for_contention_action" => "",
+        "prior_decision_text" => "The third unidentified issue (not changed)"
+      )
+    ]
   end
 
   let(:decision) do

--- a/spec/shared_context/decision_review_updated_context.rb
+++ b/spec/shared_context/decision_review_updated_context.rb
@@ -40,6 +40,7 @@ shared_context "decision_review_updated_context" do
   let(:base_decision_review_issue) do
     {
       "associated_caseflow_request_issue_id" => nil,
+      "decision_review_issue_id" => 1,
       "unidentified" => true,
       "prior_rating_decision_id" => nil,
       "prior_non_rating_decision_id" => nil,
@@ -73,14 +74,12 @@ shared_context "decision_review_updated_context" do
   let(:decision_review_issues_created) do
     [
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 123_456,
         "contention_action" => "ADD_CONTENTION",
         "reason_for_contention_action" => "NEW_ELIGIBLE_ISSUE",
         "prior_decision_text" => "An unidentified issue added during the edit"
       ),
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 123_456,
         "contention_action" => "NONE",
         "reason_for_contention_action" => "NO_CHANGES",
@@ -92,7 +91,6 @@ shared_context "decision_review_updated_context" do
   let(:decision_review_issues_updated) do
     [
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 123_456_791,
         "contention_action" => "UPDATE_CONTENTION",
         "reason_for_contention_action" => "PRIOR_DECISION_TEXT_CHANGED",
@@ -105,7 +103,7 @@ shared_context "decision_review_updated_context" do
         "time_override_reason" => "good cause exemption"
       ),
       base_decision_review_issue.merge(
-        "eligible" => true,
+        "eligible" => false,
         "eligibility_result" => "TIME_RESTRICTION",
         "decision_review_issue_id" => nil,
         "contention_id" => 123_456_791,
@@ -147,7 +145,6 @@ shared_context "decision_review_updated_context" do
         "time_override" => false
       ),
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 123_456_791,
         "contention_action" => "ADD_CONTENTION",
         "reason_for_contention_action" => "INELIGIBLE_TO_ELIGIBLE",
@@ -165,7 +162,6 @@ shared_context "decision_review_updated_context" do
   let(:decision_review_issues_removed) do
     [
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 328_253,
         "contention_action" => "DELETE_CONTENTION",
         "reason_for_contention_action" => "REMOVED_SELECTED",
@@ -178,7 +174,6 @@ shared_context "decision_review_updated_context" do
   let(:decision_review_issues_withdrawn) do
     [
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 328_252,
         "contention_action" => "DELETE_CONTENTION",
         "reason_for_contention_action" => "WITHDRAWN_SELECTED",
@@ -191,7 +186,6 @@ shared_context "decision_review_updated_context" do
   let(:decision_review_issues_not_changed) do
     [
       base_decision_review_issue.merge(
-        "decision_review_issue_id" => nil,
         "contention_id" => 328_254,
         "contention_action" => "NONE",
         "reason_for_contention_action" => "",


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-55496](https://jira.devops.va.gov/browse/APPEALS-55496)

# Description
### Value Statement: 

The Decision Review Updated event allows users to perform multiple actions on an active Decision Review (HLR/SC).  One of these actions is making a preexisting issue that is ineligible to become ineligible due to a different reason on a Decision Review.  This builder will identify issues that were previously ineligible that are now ineligible for a different reason and build request issues for the Decision Review Updated Data Transfer Object (DTO).  These issues will be placed within the ineligible_to_ineligible_issues attribute of the DTO. Also added ENUM contention_none and ineligible_reason_changed

### Implementation Notes:

The Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder will inherit from the BaseRequestIssueCollectionBuilder class (app/models/builders/base_request_issue_collection_builder.rb) and override the following methods:

build_issues - method responsible for finding and building appropriate issues for the ineligible_to_ineligible_issues attribute of the DecisionReviewUpdated DTO.
build_request_issue - method responsible for building each request issue for the ineligible_to_ineligible_issues attribute of the DecisionReviewUpdated DTO (this method is called by the build issues method).


## Acceptance Criteria

build_issues method exists and is defined:
method needs to identify DecisionReviewIssueUpdated issues that meet the following criteria using scopes:
- [x] A scope titled ineligible_to_ineligible_issues exists & has a reasonForContentionAction with a value of "INELIGIBLE_REASON_CHANGED" & a contentionAction with a value of "NONE".  This scope only retrieves issues that are part of the decisionReviewIssuesUpdated array in the DecisionReviewUpdated event.
 
build_request_issues method exists and is defined:
- [x] method needs to have a begin/rescue block with error handling
- [x] method needs to call on Builders::DecisionReviewUpdated::RequestIssueBuilder class to generate request issues.

- [x] Add DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionBuilder to BUILDERS::DecisionReviewUpdated::DTO_BUILDER class.
- [x] Add ineligible_to_ineligible_issues attribute to build_decision_review_updated_payload method in the BUILDERS::DecisionReviewUpdated::DTO_BUILDER class.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
[Test Plan](https://jira.devops.va.gov/browse/APPEALS-57202)
[Test Exec](https://jira.devops.va.gov/browse/APPEALS-57203)
[Test Xray Exec](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-57203&testIssueKey=APPEALS-57202)



# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec


### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

### Error Handling
- [x] Are errors being caught and handled gracefully?
- [x] Are appropriate error messages being displayed to users?

