### PR TITLE
cmartine/APPEALS-55464

### DIFF
--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -8,7 +8,8 @@ class Builders::BaseRequestIssueCollectionBuilder
   RATING = "RATING"
 
   REASON_FOR_CONTENTION_ACTIONS = {
-    ISSUE_REMOVED: "REMOVED_SELECTED"
+    ISSUE_REMOVED: "REMOVED_SELECTED",
+    ISSUE_WITHDRAWN: "WITHDRAWN_SELECTED"
   }.freeze
 
   CONTENTION_ACTIONS = {
@@ -116,6 +117,10 @@ class Builders::BaseRequestIssueCollectionBuilder
 
   def removed
     REASON_FOR_CONTENTION_ACTIONS[:ISSUE_REMOVED]
+  end
+
+  def withdrawn
+    REASON_FOR_CONTENTION_ACTIONS[:ISSUE_WITHDRAWN]
   end
 
   def contention_deleted

--- a/app/models/builders/decision_review_updated/withdrawn_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/withdrawn_issue_collection_builder.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
-class Builders::DecisionReviewUpdated::WithdrawnIssueCollectionBuilder
-  def self.build(decision_review_updated); end
+class Builders::DecisionReviewUpdated::WithdrawnIssueCollectionBuilder < Builders::BaseRequestIssueCollectionBuilder
+  def build_issues
+    withdrawn_issues.map.with_index do |issue, index|
+      build_request_issue(issue, index)
+    end
+  end
+
+  def build_request_issue(issue, index)
+    begin
+      Builders::DecisionReviewUpdated::RequestIssueBuilder.build(issue, @decision_review_model, @bis_rating_profiles)
+    rescue StandardError => error
+      message = "Failed building withdrawn_issues from #{self.class} for "\
+      "DecisionReview Claim ID: #{@decision_review_model.claim_id} "\
+      "#{issue_identifier_message(issue, index)} - #{error.message}"
+
+      raise AppealsConsumer::Error::RequestIssueBuildError, message
+    end
+  end
+
+  def withdrawn_issues
+    @decision_review_model.decision_review_issues_withdrawn.select do |issue|
+      issue.reason_for_contention_action == withdrawn && issue.contention_action == contention_deleted
+    end
+  end
 end

--- a/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated_request_issue.rb
@@ -35,6 +35,11 @@ FactoryBot.define do
       closed_status { "removed" }
     end
 
+    trait :withdrawn_request_issue do
+      closed_at { DateTime.new(2022, 2, 1) }
+      closed_status { "withdrawn" }
+    end
+
     trait :ineligible_to_ineligible_request_issue do
       closed_at { DateTime.new(2022, 2, 1) }
       closed_status { "ineligible" }

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
     end
     let(:removed_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :removed_request_issue)] }
     let(:cleaned_removed_issues) { dto_builder.send(:clean_pii, removed_issues) }
+    let(:withdrawn_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :withdrawn_request_issue)]}
+    let(:cleaned_withdrawn_issues) { dto_builder.send(:clean_pii, withdrawn_issues) }
 
     # rubocop:disable Layout/LineLength
     it "returns the correct payload JSON object" do
@@ -121,7 +123,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
       dto_builder.instance_variable_set(:@added_issues, "cleaned_added_issues")
       dto_builder.instance_variable_set(:@updated_issues, "cleaned_updated_issues")
       dto_builder.instance_variable_set(:@removed_issues, removed_issues)
-      dto_builder.instance_variable_set(:@withdrawn_issues, "cleaned_withdrawn_issues")
+      dto_builder.instance_variable_set(:@withdrawn_issues, withdrawn_issues)
       dto_builder.instance_variable_set(:@ineligible_to_ineligible_issues, ineligible_to_ineligible_issues)
 
       # rubocop:enable Layout/LineLength
@@ -139,7 +141,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
         "updated_issues" => "cleaned_updated_issues",
         "ineligible_to_ineligible_issues" => cleaned_ineligible_to_ineligible_issues,
         "removed_issues" => cleaned_removed_issues,
-        "withdrawn_issues" => "cleaned_withdrawn_issues"
+        "withdrawn_issues" => cleaned_withdrawn_issues
       }.as_json
       expect(payload).to eq(expected_payload)
     end

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
     end
     let(:removed_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :removed_request_issue)] }
     let(:cleaned_removed_issues) { dto_builder.send(:clean_pii, removed_issues) }
-    let(:withdrawn_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :withdrawn_request_issue)]}
+    let(:withdrawn_issues) { [FactoryBot.build(:decision_review_updated_request_issue, :withdrawn_request_issue)] }
     let(:cleaned_withdrawn_issues) { dto_builder.send(:clean_pii, withdrawn_issues) }
 
     # rubocop:disable Layout/LineLength

--- a/spec/models/builders/decision_review_updated/withdrawn_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/withdrawn_issue_collection_builder_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "shared_context/decision_review_updated_context"
+
+RSpec.describe Builders::DecisionReviewUpdated::WithdrawnIssueCollectionBuilder, type: :model do
+  subject { described_class.new(decision_review_updated) }
+
+  include_context "decision_review_updated_context"
+
+  let(:decision_review_updated) { build(:decision_review_updated, message_payload: message_payload) }
+  let(:issue) { decision_review_updated.decision_review_issues_withdrawn.first }
+  let(:index) { 1 }
+
+  describe "#build_issues" do
+    context "when successful" do
+      it "creates withdrawn_issues successfully" do
+        expect(subject.build_issues.first).to be_an_instance_of(DecisionReviewUpdated::RequestIssue)
+      end
+    end
+  end
+
+  describe "#build_request_issue" do
+    before do
+      allow(Builders::DecisionReviewUpdated::RequestIssueBuilder).to receive(:build).and_return(true)
+    end
+
+    context "when successful" do
+      it "does not raise an error" do
+        expect(subject.build_request_issue(issue, index)).to eq(true)
+      end
+    end
+
+    context "when unsuccessful" do
+      before do
+        allow(Builders::DecisionReviewUpdated::RequestIssueBuilder).to receive(:build).and_raise(StandardError)
+      end
+
+      it "raises an error" do
+        expect do
+          subject.build_request_issue(issue, index)
+        end.to raise_error(AppealsConsumer::Error::RequestIssueBuildError)
+      end
+    end
+  end
+
+  describe "#withdrawn_issues" do
+    context "when decision review withdrawn issues are present" do
+      it "returns correct number of withdrawn_issues" do
+        expect(subject.withdrawn_issues.count).to eq(1)
+      end
+
+      it "has the correct issues" do
+        subject.withdrawn_issues.each do |issue|
+          expect(issue.reason_for_contention_action).to eq("WITHDRAWN_SELECTED")
+          expect(issue.contention_action).to eq("DELETE_CONTENTION")
+        end
+      end
+    end
+
+    context "when decision review withdrawn issues are empty" do
+      before do
+        decision_review_updated.decision_review_issues_withdrawn = []
+      end
+
+      it "returns an empty array" do
+        expect(subject.withdrawn_issues).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves [Create DecisionReviewUpdated::WithdrawnIssueCollectionBuilder](https://jira.devops.va.gov/browse/APPEALS-55464)

# Description
Create DecisionReviewUpdated::WithdrawnIssueCollectionBuilder with build_issues, build_request_issue, and withdrawn_issues methods.

## Acceptance Criteria
- [X] build_issues method exists and is defined:
- [X] method needs to identify DecisionReviewIssueUpdated issues that meet the following criteria using scopes:
- [X] A scope titled withdrawn_issues exists & has a reasonForContentionAction with a value of "WITHDRAWN_SELECTED" & a contentionAction with a value of "DELETE_CONTENTION".  This scope only retrieves issues that are part of the decisionReviewIssuesWithdrawn array in the DecisionReviewUpdated event.
- [X] build_request_issues method exists and is defined:
- [X] method needs to have a begin/rescue block with error handling
- [X] method needs to call on Builders::DecisionReviewUpdated::RequestIssueBuilder class to generate request issues.

## Testing Plan
[Test Create DecisionReviewUpdated::WithdrawnIssueCollectionBuilder](https://jira.devops.va.gov/browse/APPEALS-57414)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [X] RSpec