### PR TITLE
Add decisionReviewIssueId to DecisionReviewUpdated Event & Updated naming convention of Decision Review Issues

### DIFF
--- a/app/models/builders/base_request_issue_builder.rb
+++ b/app/models/builders/base_request_issue_builder.rb
@@ -87,6 +87,7 @@ class Builders::BaseRequestIssueBuilder # rubocop:disable Metrics/ClassLength
     assign_vacols_sequence_id
     assign_nonrating_issue_bgs_id
     assign_type
+    assign_decision_review_issue_id
   end
 
   def calculate_methods

--- a/app/models/builders/base_request_issue_builder.rb
+++ b/app/models/builders/base_request_issue_builder.rb
@@ -531,4 +531,8 @@ class Builders::BaseRequestIssueBuilder
   def determine_benefit_type
     decision_review_model.ep_code.include?(PENSION_IDENTIFIER) ? PENSION_BENEFIT_TYPE : COMPENSATION_BENEFIT_TYPE
   end
+
+  def assign_decision_review_issue_id
+    @request_issue.decision_review_issue_id = issue.decision_review_issue_id
+  end
 end

--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -61,7 +61,7 @@ class Builders::BaseRequestIssueCollectionBuilder
   private
 
   def issues
-    @issues ||= @decision_review_model.decision_review_issues
+    @issues ||= @decision_review_model.decision_review_issues_created
   end
 
   def message_has_rating_issues?

--- a/app/models/builders/base_request_issue_collection_builder.rb
+++ b/app/models/builders/base_request_issue_collection_builder.rb
@@ -76,13 +76,6 @@ class Builders::BaseRequestIssueCollectionBuilder
     issues.any?(&:prior_rating_decision_id)
   end
 
-  def handle_no_issues_after_removing_contested
-    fail AppealsConsumer::Error::RequestIssueCollectionBuildError, "Failed building from"\
-      " #{self.class} for DecisionReview Claim ID:"\
-      " #{@decision_review_model.claim_id} does not contain any valid issues after"\
-      " removing 'CONTESTED' ineligible issues"
-  end
-
   def build_request_issue(issue, index)
     fail NotImplementedError, "#{self.class} must implement the build_request_issue method"
   end

--- a/app/models/builders/decision_review_created/claim_review_builder.rb
+++ b/app/models/builders/decision_review_created/claim_review_builder.rb
@@ -83,7 +83,7 @@ class Builders::DecisionReviewCreated::ClaimReviewBuilder
   end
 
   def any_opted_in_issues?
-    decision_review_model.decision_review_issues.any? { |issue| !!issue.soc_opt_in }
+    decision_review_model.decision_review_issues_created.any? { |issue| !!issue.soc_opt_in }
   end
 
   def veteran_and_claimant_participant_ids_different?

--- a/app/models/builders/decision_review_created/request_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_collection_builder.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# This class is used to build out an array of Request Issues from decision_review_created.decision_review_issues
+# This class is used to build out an array of Request Issues from decision_review_created.decision_review_issues_created
 class Builders::DecisionReviewCreated::RequestIssueCollectionBuilder < Builders::BaseRequestIssueCollectionBuilder
-  # valid_issues are the decision_review_issues that don't have "CONTESTED" eligibility_result
+  # valid_issues are the decision_review_issues_created that don't have "CONTESTED" eligibility_result
   def build_issues
     issues.map.with_index do |issue, index|
       build_request_issue(issue, index)

--- a/app/models/builders/decision_review_created/request_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_collection_builder.rb
@@ -2,7 +2,6 @@
 
 # This class is used to build out an array of Request Issues from decision_review_created.decision_review_issues_created
 class Builders::DecisionReviewCreated::RequestIssueCollectionBuilder < Builders::BaseRequestIssueCollectionBuilder
-  # valid_issues are the decision_review_issues_created that don't have "CONTESTED" eligibility_result
   def build_issues
     issues.map.with_index do |issue, index|
       build_request_issue(issue, index)

--- a/app/models/builders/decision_review_updated/eligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/eligible_to_ineligible_issue_collection_builder.rb
@@ -2,7 +2,6 @@
 
 class Builders::DecisionReviewUpdated::EligibleToIneligibleIssueCollectionBuilder <
       Builders::BaseRequestIssueCollectionBuilder
-  # valid_issues are the decision_review_issues_created that don't have "CONTESTED" eligibility_result
   def build_issues
     eligible_to_ineligible_issues = eligible_to_ineligible_issue
 

--- a/app/models/builders/decision_review_updated/eligible_to_ineligible_issue_collection_builder.rb
+++ b/app/models/builders/decision_review_updated/eligible_to_ineligible_issue_collection_builder.rb
@@ -2,7 +2,7 @@
 
 class Builders::DecisionReviewUpdated::EligibleToIneligibleIssueCollectionBuilder <
       Builders::BaseRequestIssueCollectionBuilder
-  # valid_issues are the decision_review_issues that don't have "CONTESTED" eligibility_result
+  # valid_issues are the decision_review_issues_created that don't have "CONTESTED" eligibility_result
   def build_issues
     eligible_to_ineligible_issues = eligible_to_ineligible_issue
 

--- a/app/models/builders/decision_review_updated/request_issue_builder.rb
+++ b/app/models/builders/decision_review_updated/request_issue_builder.rb
@@ -9,18 +9,9 @@ class Builders::DecisionReviewUpdated::RequestIssueBuilder < Builders::BaseReque
     super(issue, decision_review_model, bis_rating_profiles, @request_issue)
   end
 
-  def assign_methods
-    assign_decision_review_issue_id
-    super
-  end
-
   def calculate_methods
     calculate_edited_description
     super
-  end
-
-  def assign_decision_review_issue_id
-    @request_issue.decision_review_issue_id = issue.decision_review_issue_id
   end
 
   def calculate_closed_at

--- a/app/models/builders/decision_review_updated/request_issue_builder.rb
+++ b/app/models/builders/decision_review_updated/request_issue_builder.rb
@@ -9,6 +9,11 @@ class Builders::DecisionReviewUpdated::RequestIssueBuilder < Builders::BaseReque
     super(issue, decision_review_model, bis_rating_profiles, @request_issue)
   end
 
+  def assign_methods
+    assign_original_caseflow_request_issue_id
+    super
+  end
+
   def calculate_methods
     calculate_edited_description
     super
@@ -34,5 +39,9 @@ class Builders::DecisionReviewUpdated::RequestIssueBuilder < Builders::BaseReque
     if edited_description?
       @request_issue.edited_description = issue.prior_decision_text
     end
+  end
+
+  def assign_original_caseflow_request_issue_id
+    @request_issue.original_caseflow_request_issue_id = issue.original_caseflow_request_issue_id
   end
 end

--- a/app/models/virtual/base_request_issue.rb
+++ b/app/models/virtual/base_request_issue.rb
@@ -3,9 +3,9 @@
 class BaseRequestIssue
   attr_accessor :contested_issue_description, :contention_reference_id, :contested_rating_decision_reference_id,
                 :contested_rating_issue_profile_date, :contested_rating_issue_reference_id,
-                :contested_decision_issue_id, :decision_date, :ineligible_due_to_id, :ineligible_reason,
-                :is_unidentified, :unidentified_issue_text, :nonrating_issue_category, :nonrating_issue_description,
-                :untimely_exemption, :untimely_exemption_notes, :vacols_id, :vacols_sequence_id, :benefit_type,
-                :closed_at, :closed_status, :contested_rating_issue_diagnostic_code, :ramp_claim_id,
-                :rating_issue_associated_at, :type, :nonrating_issue_bgs_id, :nonrating_issue_bgs_source
+                :contested_decision_issue_id, :decision_date, :decision_review_issue_id, :ineligible_due_to_id,
+                :ineligible_reason, :is_unidentified, :unidentified_issue_text, :nonrating_issue_category,
+                :nonrating_issue_description, :untimely_exemption, :untimely_exemption_notes, :vacols_id,
+                :vacols_sequence_id, :benefit_type, :closed_at, :closed_status, :contested_rating_issue_diagnostic_code,
+                :ramp_claim_id, :rating_issue_associated_at, :type, :nonrating_issue_bgs_id, :nonrating_issue_bgs_source
 end

--- a/app/models/virtual/decision_review_updated/request_issue.rb
+++ b/app/models/virtual/decision_review_updated/request_issue.rb
@@ -2,5 +2,5 @@
 
 # This class should be instantiated via Builders::DecisionReviewUpdeted::RequestIssueBuilder
 class DecisionReviewUpdated::RequestIssue < BaseRequestIssue
-  attr_accessor :decision_review_issue_id, :edited_description
+  attr_accessor :edited_description
 end

--- a/app/models/virtual/decision_review_updated/request_issue.rb
+++ b/app/models/virtual/decision_review_updated/request_issue.rb
@@ -2,5 +2,5 @@
 
 # This class should be instantiated via Builders::DecisionReviewUpdeted::RequestIssueBuilder
 class DecisionReviewUpdated::RequestIssue < BaseRequestIssue
-  attr_accessor :edited_description
+  attr_accessor :edited_description, :original_caseflow_request_issue_id
 end

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -44,7 +44,7 @@ class Transformers::DecisionReviewCreated
 
   # When DecisionReviewCreated.new(message_payload) is called, this method will validate message_payload
   # presence, attribute names and data types, assign the incoming attributes to defined keys,
-  # and create DecisionReviewIssue instances for each object in the message_payload's
+  # and create DecisionReviewIssueCreated instances for each object in the message_payload's
   # decision_review_issues_created array
   def initialize(event_id, message_payload = {})
     @event_id = event_id
@@ -79,7 +79,7 @@ class Transformers::DecisionReviewCreated
   end
 end
 
-# DecisionReviewIssue represents an individual issue object from the message_payload's
+# DecisionReviewIssueCreated represents an individual issue object from the message_payload's
 # decision_review_issues_created array
 class DecisionReviewIssueCreated
   include MessagePayloadValidator
@@ -123,7 +123,7 @@ class DecisionReviewIssueCreated
   # Allows read and write access for attributes
   DECISION_REVIEW_ISSUE_CREATED_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
 
-  # When DecisionReviewIssue.new(issue_attrs) is called, this method will validate message_payload
+  # When DecisionReviewIssueCreated.new(issue_attrs) is called, this method will validate message_payload
   # presence, attribute names and data types and assign the incoming attributes to defined keys
   def initialize(issue = {})
     validate(issue, self.class.name)

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -44,7 +44,7 @@ class Transformers::DecisionReviewCreated
 
   # When DecisionReviewCreated.new(message_payload) is called, this method will validate message_payload
   # presence, attribute names and data types, assign the incoming attributes to defined keys,
-  # and create DecisionReviewIssue instances for each object in the message_payload's 
+  # and create DecisionReviewIssue instances for each object in the message_payload's
   # decision_review_issues_created array
   def initialize(event_id, message_payload = {})
     @event_id = event_id
@@ -79,7 +79,7 @@ class Transformers::DecisionReviewCreated
   end
 end
 
-# DecisionReviewIssue represents an individual issue object from the message_payload's 
+# DecisionReviewIssue represents an individual issue object from the message_payload's
 # decision_review_issues_created array
 class DecisionReviewIssueCreated
   include MessagePayloadValidator

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -34,8 +34,8 @@ class Transformers::DecisionReviewCreated
     "actor_username" => String,
     "actor_station" => String,
     "actor_application" => String,
-    "decision_review_issues" => Array,
-    "auto_remand" => [TrueClass, FalseClass]
+    "auto_remand" => [TrueClass, FalseClass],
+    "decision_review_issues_created" => Array
   }
   # rubocop:enable Style/MutableConstant
 
@@ -62,31 +62,31 @@ class Transformers::DecisionReviewCreated
   def assign(message_payload)
     DECISION_REVIEW_CREATED_ATTRIBUTES.each_key { |attr| instance_variable_set("@#{attr}", message_payload[attr]) }
 
-    decision_review_issues_array = message_payload["decision_review_issues"]
-    @decision_review_issues = create_decision_review_issues(decision_review_issues_array)
+    decision_review_issues_created_array = message_payload["decision_review_issues_created"]
+    @decision_review_issues_created = create_decision_review_issues_created(decision_review_issues_created_array)
   end
 
   # Creates instances of DecisionReviewIssue, validates attributes, and assigns attributes
   # for each object in the decision_review_issues array
   # Fails out of workflow if decision_review_issues is an empty array
-  def create_decision_review_issues(decision_review_issues)
-    if decision_review_issues.blank?
-      fail ArgumentError, "#{self.class.name}: Message payload must include at least one decision review issue"
+  def create_decision_review_issues_created(decision_review_issues_created)
+    if decision_review_issues_created.blank?
+      fail ArgumentError, "#{self.class.name}: Message payload must include at least one decision review issue created"
     end
 
-    decision_review_issues.map { |issue| DecisionReviewIssue.new(issue) }
+    decision_review_issues_created.map { |issue| DecisionReviewIssueCreated.new(issue) }
   end
 end
 
 # DecisionReviewIssue represents an individual issue object from the message_payload's decision_review_issues array
-class DecisionReviewIssue
+class DecisionReviewIssueCreated
   include MessagePayloadValidator
 
   # Lists the attributes and corresponding data types
   # Data types are stored in an array when the value isn't limited to one data type
   # For example, time_override could be a boolean OR nil
   # rubocop:disable Style/MutableConstant
-  DECISION_REVIEW_ISSUE_ATTRIBUTES ||= {
+  DECISION_REVIEW_ISSUE_CREATED_ATTRIBUTES ||= {
     "decision_review_issue_id" => [Integer],
     "contention_id" => [Integer, NilClass],
     "prior_caseflow_decision_issue_id" => [Integer, NilClass],
@@ -119,7 +119,7 @@ class DecisionReviewIssue
   # rubocop:enable Style/MutableConstant
 
   # Allows read and write access for attributes
-  DECISION_REVIEW_ISSUE_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
+  DECISION_REVIEW_ISSUE_CREATED_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
 
   # When DecisionReviewIssue.new(issue_attrs) is called, this method will validate message_payload
   # presence, attribute names and data types and assign the incoming attributes to defined keys
@@ -132,11 +132,11 @@ class DecisionReviewIssue
 
   # Lists the attributes and corresponding data types
   def attribute_types
-    DECISION_REVIEW_ISSUE_ATTRIBUTES
+    DECISION_REVIEW_ISSUE_CREATED_ATTRIBUTES
   end
 
   # Assigns attributes from issue_attrs to defined keys
   def assign(issue)
-    DECISION_REVIEW_ISSUE_ATTRIBUTES.each_key { |attr| instance_variable_set("@#{attr}", issue[attr]) }
+    DECISION_REVIEW_ISSUE_CREATED_ATTRIBUTES.each_key { |attr| instance_variable_set("@#{attr}", issue[attr]) }
   end
 end

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -44,7 +44,8 @@ class Transformers::DecisionReviewCreated
 
   # When DecisionReviewCreated.new(message_payload) is called, this method will validate message_payload
   # presence, attribute names and data types, assign the incoming attributes to defined keys,
-  # and create DecisionReviewIssue instances for each object in the message_payload's decision_review_issues array
+  # and create DecisionReviewIssue instances for each object in the message_payload's 
+  # decision_review_issues_created array
   def initialize(event_id, message_payload = {})
     @event_id = event_id
     validate(message_payload, self.class.name)
@@ -67,8 +68,8 @@ class Transformers::DecisionReviewCreated
   end
 
   # Creates instances of DecisionReviewIssue, validates attributes, and assigns attributes
-  # for each object in the decision_review_issues array
-  # Fails out of workflow if decision_review_issues is an empty array
+  # for each object in the decision_review_issues_created array
+  # Fails out of workflow if decision_review_issues_created is an empty array
   def create_decision_review_issues_created(decision_review_issues_created)
     if decision_review_issues_created.blank?
       fail ArgumentError, "#{self.class.name}: Message payload must include at least one decision review issue created"
@@ -78,7 +79,8 @@ class Transformers::DecisionReviewCreated
   end
 end
 
-# DecisionReviewIssue represents an individual issue object from the message_payload's decision_review_issues array
+# DecisionReviewIssue represents an individual issue object from the message_payload's 
+# decision_review_issues_created array
 class DecisionReviewIssueCreated
   include MessagePayloadValidator
 

--- a/app/models/virtual/transformers/decision_review_created.rb
+++ b/app/models/virtual/transformers/decision_review_created.rb
@@ -87,6 +87,7 @@ class DecisionReviewIssue
   # For example, time_override could be a boolean OR nil
   # rubocop:disable Style/MutableConstant
   DECISION_REVIEW_ISSUE_ATTRIBUTES ||= {
+    "decision_review_issue_id" => [Integer],
     "contention_id" => [Integer, NilClass],
     "prior_caseflow_decision_issue_id" => [Integer, NilClass],
     "associated_caseflow_request_issue_id" => [Integer, NilClass],

--- a/app/models/virtual/transformers/decision_review_updated.rb
+++ b/app/models/virtual/transformers/decision_review_updated.rb
@@ -145,6 +145,7 @@ class DecisionReviewIssueUpdated
     "prior_decision_rating_profile_date" => [String, NilClass],
     "source_claim_id_for_remand" => [Integer, NilClass],
     "source_contention_id_for_remand" => [Integer, NilClass],
+    "original_caseflow_request_issue_id" => [Integer, NilClass],
     "removed" => [TrueClass, FalseClass],
     "withdrawn" => [TrueClass, FalseClass],
     "decision" => [Hash, NilClass]

--- a/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_CREATED_V01.avsc
+++ b/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_CREATED_V01.avsc
@@ -157,11 +157,11 @@
       "doc": "True/false value to indicate whether or not this decision review is an automatically established remand."
     },
     {
-      "name": "decisionReviewIssues",
+      "name": "decisionReviewIssuesCreated",
       "type": {
         "type": "array",
         "items": {
-          "name": "DecisionReviewIssue",
+          "name": "DecisionReviewIssueCreated",
           "type": "record",
           "fields": [
             {

--- a/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_CREATED_V01.avsc
+++ b/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_CREATED_V01.avsc
@@ -165,6 +165,11 @@
           "type": "record",
           "fields": [
             {
+              "name": "decisionReviewIssueId",
+              "type": "long",
+              "doc": "The ID of the decision review issue record internal to C&P."
+            },
+            {
               "name": "contentionId",
               "type": [
                 "null",

--- a/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_UPDATED_V01.avsc
+++ b/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_UPDATED_V01.avsc
@@ -422,6 +422,15 @@
                 "doc": "The ID of the contention that was assigned a disposition that triggered the auto-establishment of this remand decision review, if applicable. This field is not updatable and is only for reference."
               },
               {
+                "name": "originalCaseflowRequestIssueId",
+                "type": [
+                  "null",
+                  "long"
+                ],
+                "default": null,
+                "doc": "When the originalSource is CASEFLOW (meaning the decision reveiw was backfilled from Caseflow), this represents the request issues ID in Caseflow."
+              },
+              {
                 "name": "removed",
                 "type": "boolean",
                 "default": false,

--- a/lib/kafka_message_generators/base.rb
+++ b/lib/kafka_message_generators/base.rb
@@ -37,7 +37,7 @@ class KafkaMessageGenerators::Base
   # for each event type. Used in the Decision Review Events class
   def issue_types
     @issue_types ||= {
-      decision_review_created: [:decision_review_issues],
+      decision_review_created: [:decision_review_issues_created],
       decision_review_updated: [
         :decision_review_issues_created,
         :decision_review_issues_not_changed,

--- a/lib/kafka_message_generators/decision_review_events.rb
+++ b/lib/kafka_message_generators/decision_review_events.rb
@@ -798,11 +798,11 @@ module KafkaMessageGenerators
       issue_types.fetch(@decision_review_event_type.to_sym, []).each do |issue_type|
         next if object.send(issue_type).empty?
 
-        if issue_type == :decision_review_issues_created &&
+        if decision_review_updated? && issue_type == :decision_review_issues_created &&
            object.send(:decision_review_issues_created)[0].contention_action == "ADD_CONTENTION"
           object.send(issue_type)[0].contention_id = @new_contention_id
           @new_contention_id += 1
-        elsif issue_type == :decision_review_issues_created &&
+        elsif decision_review_updated? && issue_type == :decision_review_issues_created &&
               object.send(:decision_review_issues_created)[0].contention_action == "NONE"
           object.send(issue_type)[0].contention_id = nil
         else

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     nonrating_hlr_veteran_claimant
 
     transient do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -91,24 +91,24 @@ FactoryBot.define do
       event_id { nil }
     end
 
-    trait :without_decision_review_issues do
-      decision_review_issues { [] }
+    trait :without_decision_review_issues_created do
+      decision_review_issues_created { [] }
     end
 
-    trait :with_nil_decision_review_issue do
-      decision_review_issues { [nil, nil] }
+    trait :with_nil_decision_review_issue_created do
+      decision_review_issues_created { [nil, nil] }
     end
 
-    trait :with_empty_decision_review_issue do
-      decision_review_issues { [{}, {}] }
+    trait :with_empty_decision_review_issue_created do
+      decision_review_issues_created { [{}, {}] }
     end
 
-    trait :with_invalid_decision_review_issue_attribute_name do
-      decision_review_issues { [{ "invalid_attribute" => "is invalid" }] }
+    trait :with_invalid_decision_review_issue_created_attribute_name do
+      decision_review_issues_created { [{ "invalid_attribute" => "is invalid" }] }
     end
 
-    trait :with_invalid_decision_review_issue_data_type do
-      decision_review_issues { [{ "decision_review_issue_id" => "777" }] }
+    trait :with_invalid_decision_review_issue_created_data_type do
+      decision_review_issues_created { [{ "decision_review_issue_id" => "777" }] }
     end
     # END: Payloads that raise error upon DecisionReviewCreated initialization
 
@@ -140,7 +140,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -173,7 +173,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -206,7 +206,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -239,7 +239,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -272,7 +272,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -307,7 +307,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -340,7 +340,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -373,7 +373,7 @@ FactoryBot.define do
           "actor_station" => "101",
           "actor_application" => "PASYSACCTCREATE",
           "auto_remand" => false,
-          "decision_review_issues" => decision_review_issues
+          "decision_review_issues_created" => decision_review_issues_created
         }
       end
       event_id { nil }
@@ -384,7 +384,7 @@ FactoryBot.define do
     ## Nonating HLR
     ### START: Valid Eligible Nonrating HLR
     trait :eligible_nonrating_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -429,7 +429,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_with_two_issues do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -492,7 +492,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_contested_with_additional_issue do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -555,7 +555,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_time_override do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -590,7 +590,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_with_decision_source do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -626,7 +626,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_legacy do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -663,7 +663,7 @@ FactoryBot.define do
 
     ### START: Valid Ineligible Nonrating HLR
     trait :ineligible_nonrating_hlr_pending_board_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -698,7 +698,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_pending_supplemental do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -733,7 +733,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_time_restriction_untimely do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -768,7 +768,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_time_restriction_before_ama do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -803,7 +803,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_no_soc_ssoc do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -838,7 +838,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_pending_legacy_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -873,7 +873,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_legacy_time_restriction do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -908,7 +908,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_pending_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -943,7 +943,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_completed_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -978,7 +978,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_contested do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1013,7 +1013,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_completed_board_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1051,7 +1051,7 @@ FactoryBot.define do
     ### START: Invalid Nonrating HLR
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_nonrating_hlr_without_prior_decision_date do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1086,7 +1086,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_pending_hlr_without_ri_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1121,7 +1121,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_with_contention_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1156,7 +1156,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_without_contention_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1191,7 +1191,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_nonrating_hlr_contested do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1232,7 +1232,7 @@ FactoryBot.define do
     # unidentified issues will never be ineligible upon being intaken,
     # eligibility is determined once the issue is identified
     trait :eligible_nonrating_hlr_unidentified do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1267,7 +1267,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_unidentified_with_decision_source do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1315,7 +1315,7 @@ FactoryBot.define do
     ### START: Invalid Nonrating Unidentified HLR
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_nonrating_hlr_unidentified_without_prior_decision_date do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1350,7 +1350,7 @@ FactoryBot.define do
     end
 
     trait :eligible_nonrating_hlr_unidentified_without_contention_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1389,7 +1389,7 @@ FactoryBot.define do
     ## START: Nonrating Prior Caseflow Decision Issue HLR
     ### START: Valid Eligible Nonrating Prior Caseflow Decision Issue HLR
     trait :eligible_decision_issue_prior_nonrating_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1433,7 +1433,7 @@ FactoryBot.define do
     end
 
     trait :eligible_decision_issue_prior_nonrating_hlr_time_override do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1468,7 +1468,7 @@ FactoryBot.define do
     end
 
     trait :eligible_decision_issue_prior_nonrating_hlr_with_decision_source do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1504,7 +1504,7 @@ FactoryBot.define do
     end
 
     trait :eligible_decision_issue_prior_nonrating_hlr_legacy do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1542,7 +1542,7 @@ FactoryBot.define do
     ### START: Invalid Nonrating Prior Caseflow Decision Issue HLR
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_decision_issue_prior_nonrating_hlr_without_prior_decision_date do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1576,7 +1576,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_pending_hlr_without_ri_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1611,7 +1611,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_with_contention_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1646,7 +1646,7 @@ FactoryBot.define do
     end
 
     trait :eligible_decision_issue_prior_nonrating_hlr_without_contention_id do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1683,7 +1683,7 @@ FactoryBot.define do
 
     ### START: Valid Ineligible Nonrating Prior Caseflow Decision Issue HLR
     trait :ineligible_decision_issue_prior_nonrating_hlr_time_restriction_untimely do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1718,7 +1718,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_time_restriction_before_ama do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1753,7 +1753,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_no_soc_ssoc do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1788,7 +1788,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_pending_legacy_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1823,7 +1823,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_legacy_time_restriction do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1858,7 +1858,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_pending_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1893,7 +1893,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_pending_board_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1928,7 +1928,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_pending_supplemental do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1963,7 +1963,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_completed_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -1998,7 +1998,7 @@ FactoryBot.define do
     end
 
     trait :ineligible_decision_issue_prior_nonrating_hlr_completed_board_appeal do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2037,7 +2037,7 @@ FactoryBot.define do
     ## Rating HLR
     ### START: Valid Eligible Rating HLR
     trait :eligible_rating_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2083,7 +2083,7 @@ FactoryBot.define do
 
     trait :eligible_rating_hlr_time_override do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2119,7 +2119,7 @@ FactoryBot.define do
 
     trait :eligible_rating_hlr_with_two_issues do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2183,7 +2183,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_contested_with_additional_issue do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2247,7 +2247,7 @@ FactoryBot.define do
 
     trait :eligible_rating_hlr_legacy do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2285,7 +2285,7 @@ FactoryBot.define do
     ### START: Valid Ineligible Rating HLR
     trait :ineligible_rating_hlr_pending_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2321,7 +2321,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_pending_supplemental do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2357,7 +2357,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_time_restriction_untimely do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2393,7 +2393,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_time_restriction_before_ama do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2429,7 +2429,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_no_soc_ssoc do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2465,7 +2465,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_pending_legacy_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2501,7 +2501,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_legacy_time_restriction do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2537,7 +2537,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_pending_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2573,7 +2573,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_completed_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2609,7 +2609,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_completed_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2648,7 +2648,7 @@ FactoryBot.define do
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_rating_hlr_without_prior_decision_date do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2684,7 +2684,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_pending_hlr_without_ri_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2720,7 +2720,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_contested do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2756,7 +2756,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_hlr_with_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2792,7 +2792,7 @@ FactoryBot.define do
 
     trait :eligible_rating_hlr_without_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2833,7 +2833,7 @@ FactoryBot.define do
     # unidentified issues will never be ineligible upon being intaken,
     # eligibility is determined once the issue is identified
     trait :eligible_rating_hlr_unidentified do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2882,7 +2882,7 @@ FactoryBot.define do
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_rating_hlr_unidentified_without_prior_decision_date do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2918,7 +2918,7 @@ FactoryBot.define do
 
     trait :eligible_rating_hlr_unidentified_without_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -2958,7 +2958,7 @@ FactoryBot.define do
     ### START: Valid Eligible Rating Prior Caseflow Decision Issue HLR
     trait :eligible_decision_issue_prior_rating_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3004,7 +3004,7 @@ FactoryBot.define do
 
     trait :eligible_decision_issue_prior_rating_hlr_time_override do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3040,7 +3040,7 @@ FactoryBot.define do
 
     trait :eligible_decision_issue_prior_rating_hlr_legacy do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3079,7 +3079,7 @@ FactoryBot.define do
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_decision_issue_prior_rating_hlr_without_prior_decision_date do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3115,7 +3115,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_pending_hlr_without_ri_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3151,7 +3151,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_with_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3187,7 +3187,7 @@ FactoryBot.define do
 
     trait :eligible_decision_issue_prior_rating_hlr_without_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3226,7 +3226,7 @@ FactoryBot.define do
     ### START: Valid Ineligible Rating Prior Caseflow Decision Issue HLR
     trait :ineligible_decision_issue_prior_rating_hlr_time_restriction_untimely do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3262,7 +3262,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_time_restriction_before_ama do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3298,7 +3298,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_no_soc_ssoc do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3334,7 +3334,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_pending_legacy_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3370,7 +3370,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_legacy_time_restriction do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3406,7 +3406,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_pending_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3442,7 +3442,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_pending_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3478,7 +3478,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_pending_supplemental do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3514,7 +3514,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_completed_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3550,7 +3550,7 @@ FactoryBot.define do
 
     trait :ineligible_decision_issue_prior_rating_hlr_completed_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3589,7 +3589,7 @@ FactoryBot.define do
     ## START: Rating Decision HLR
     ### START: Valid Eligible Rating Decision HLR
     trait :eligible_rating_decision_hlr do
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3635,7 +3635,7 @@ FactoryBot.define do
 
     trait :eligible_rating_decision_hlr_time_override do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3671,7 +3671,7 @@ FactoryBot.define do
 
     trait :eligible_rating_decision_hlr_legacy do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3710,7 +3710,7 @@ FactoryBot.define do
     # these records will fail to process within DecisionReviewCreatedEvenprocessingJob
     trait :eligible_rating_decision_hlr_without_prior_decision_date do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3746,7 +3746,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_pending_hlr_without_ri_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3782,7 +3782,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_with_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3818,7 +3818,7 @@ FactoryBot.define do
 
     trait :eligible_rating_decision_hlr_without_contention_id do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3856,7 +3856,7 @@ FactoryBot.define do
     ### START: Valid Ineligible Rating Decision HLR
     trait :ineligible_rating_decision_hlr_time_restriction_untimely do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3892,7 +3892,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_time_restriction_before_ama do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3928,7 +3928,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_no_soc_ssoc do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -3964,7 +3964,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_pending_legacy_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4000,7 +4000,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_legacy_time_restriction do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4036,7 +4036,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_pending_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4072,7 +4072,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_pending_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4108,7 +4108,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_pending_supplemental do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4144,7 +4144,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_completed_hlr do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,
@@ -4180,7 +4180,7 @@ FactoryBot.define do
 
     trait :ineligible_rating_decision_hlr_completed_board_appeal do
       rating_hlr_veteran_claimant
-      decision_review_issues do
+      decision_review_issues_created do
         [
           {
             "decision_review_issue_id" => 777,

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -981,6 +981,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_789,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -37,6 +38,7 @@ FactoryBot.define do
             "prior_decision_source" => nil
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_790,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -106,7 +108,7 @@ FactoryBot.define do
     end
 
     trait :with_invalid_decision_review_issue_data_type do
-      decision_review_issues { [{ "contention_id" => "is supposed to be an integer" }] }
+      decision_review_issues { [{ "decision_review_issue_id" => "777" }] }
     end
     # END: Payloads that raise error upon DecisionReviewCreated initialization
 
@@ -385,6 +387,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -429,6 +432,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -456,6 +460,7 @@ FactoryBot.define do
             "source_claim_id_for_remand" => nil
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -490,6 +495,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -517,6 +523,7 @@ FactoryBot.define do
             "source_claim_id_for_remand" => nil
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -551,6 +558,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -585,6 +593,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -620,6 +629,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -656,6 +666,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 13,
@@ -690,6 +701,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 13,
@@ -724,6 +736,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -758,6 +771,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -792,6 +806,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -826,6 +841,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -860,6 +876,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -894,6 +911,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 12,
@@ -928,6 +946,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -962,6 +981,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -999,6 +1019,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1033,6 +1054,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1067,6 +1089,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1101,6 +1124,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1135,6 +1159,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1175,6 +1200,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 12_345_980,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1209,6 +1235,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 12_345_980,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1256,6 +1283,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 12_345_980,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1290,6 +1318,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -1328,6 +1357,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_792,
             "prior_caseflow_decision_issue_id" => 11,
             "associated_caseflow_request_issue_id" => nil,
@@ -1371,6 +1401,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 20,
             "associated_caseflow_request_issue_id" => nil,
@@ -1405,6 +1436,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 20,
             "associated_caseflow_request_issue_id" => nil,
@@ -1440,6 +1472,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1477,6 +1510,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_792,
             "prior_caseflow_decision_issue_id" => 11,
             "associated_caseflow_request_issue_id" => nil,
@@ -1510,6 +1544,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1544,6 +1579,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1578,6 +1614,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1614,6 +1651,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1648,6 +1686,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 20,
             "associated_caseflow_request_issue_id" => nil,
@@ -1682,6 +1721,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1716,6 +1756,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1750,6 +1791,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1784,6 +1826,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -1818,6 +1861,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -1852,6 +1896,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -1886,6 +1931,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1920,6 +1966,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -1958,6 +2005,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2003,6 +2051,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2038,6 +2087,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2065,6 +2115,7 @@ FactoryBot.define do
             "source_claim_id_for_remand" => nil
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2100,6 +2151,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2127,6 +2179,7 @@ FactoryBot.define do
             "source_claim_id_for_remand" => nil
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2162,6 +2215,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2199,6 +2253,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 13,
@@ -2234,6 +2289,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 13,
@@ -2269,6 +2325,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2304,6 +2361,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2339,6 +2397,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2374,6 +2433,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2409,6 +2469,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2444,6 +2505,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 12,
@@ -2479,6 +2541,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2514,6 +2577,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2552,6 +2616,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2587,6 +2652,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2622,6 +2688,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2657,6 +2724,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2692,6 +2760,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2732,6 +2801,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 12_345_980,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2780,6 +2850,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 12_345_980,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2815,6 +2886,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -2854,6 +2926,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_792,
             "prior_caseflow_decision_issue_id" => 11,
             "associated_caseflow_request_issue_id" => nil,
@@ -2899,6 +2972,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 20,
             "associated_caseflow_request_issue_id" => nil,
@@ -2934,6 +3008,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -2972,6 +3047,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_792,
             "prior_caseflow_decision_issue_id" => 11,
             "associated_caseflow_request_issue_id" => nil,
@@ -3007,6 +3083,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3042,6 +3119,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3077,6 +3155,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3115,6 +3194,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3150,6 +3230,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 20,
             "associated_caseflow_request_issue_id" => nil,
@@ -3185,6 +3266,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3220,6 +3302,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3255,6 +3338,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3290,6 +3374,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -3325,6 +3410,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -3360,6 +3446,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => 12,
@@ -3395,6 +3482,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3430,6 +3518,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => 13,
             "associated_caseflow_request_issue_id" => nil,
@@ -3468,6 +3557,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3513,6 +3603,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3548,6 +3639,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3586,6 +3678,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3621,6 +3714,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3656,6 +3750,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_791,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3691,6 +3786,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3728,6 +3824,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3763,6 +3860,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3798,6 +3896,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3833,6 +3932,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3868,6 +3968,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -3903,6 +4004,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 12,
@@ -3938,6 +4040,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 12,
@@ -3973,6 +4076,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => 12,
@@ -4008,6 +4112,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,
@@ -4043,6 +4148,7 @@ FactoryBot.define do
       decision_review_issues do
         [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => nil,
             "prior_caseflow_decision_issue_id" => nil,
             "associated_caseflow_request_issue_id" => nil,

--- a/spec/factories/decision_review_created_event.rb
+++ b/spec/factories/decision_review_created_event.rb
@@ -30,6 +30,7 @@ FactoryBot.define do
         "auto_remand" => false,
         "decision_review_issues" => [
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 123_456_789,
             "associated_caseflow_request_issue_id" => nil,
             "unidentified" => false,
@@ -53,6 +54,7 @@ FactoryBot.define do
             "source_claim_id_for_remand" => 1
           },
           {
+            "decision_review_issue_id" => 777,
             "contention_id" => 987_654_321,
             "associated_caseflow_request_issue_id" => nil,
             "unidentified" => false,

--- a/spec/factories/decision_review_created_event.rb
+++ b/spec/factories/decision_review_created_event.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
         "actor_station" => "101",
         "actor_application" => "PASYSACCTCREATE",
         "auto_remand" => false,
-        "decision_review_issues" => [
+        "decision_review_issues_created" => [
           {
             "decision_review_issue_id" => 777,
             "contention_id" => 123_456_789,

--- a/spec/factories/decision_review_updated/decision_review_updated.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated.rb
@@ -3443,6 +3443,7 @@ FactoryBot.define do
       message_payload do
         base_message_payload(
           participant_id: participant_id,
+          original_source: "CASEFLOW",
           same_station_review_requested: true,
           decision_review_issues_created:
           [
@@ -3456,6 +3457,15 @@ FactoryBot.define do
           ],
           decision_review_issues_updated:
           [
+            review_issues_updated_attributes(
+              "reason_for_contention_action" => "INELIGIBLE_REASON_CHANGED",
+              "contention_action" => "NONE",
+              "original_caseflow_request_issue_id" => 123_45,
+              "prior_rating_decision_id" => 12,
+              "prior_decision_type" => "Disability Evaluation",
+              "prior_decision_diagnostic_code" => "5008",
+              "eligibility_result" => "PENDING_SUPPLEMENTAL"
+            ),
             review_issues_updated_attributes(
               "reason_for_contention_action" => "SPECIAL_ISSUES_CHANGED",
               "associated_caseflow_request_issue_id" => 13,
@@ -3488,7 +3498,7 @@ FactoryBot.define do
           decision_review_issues_not_changed:
           [
             review_issues_not_changed_attributes(
-              "associated_caseflow_request_issue_id" => 13,
+              "original_caseflow_request_issue_id" => 123_45,
               "prior_rating_decision_id" => 12,
               "prior_decision_type" => "Disability Evaluation",
               "prior_decision_diagnostic_code" => "5008",
@@ -7030,7 +7040,7 @@ end
 def base_message_payload(**args)
   {
     "claim_id" => Faker::Number.number(digits: 7),
-    "original_source" => "CP",
+    "original_source" => args[:original_source] || "CP",
     "decision_review_type" => "HIGHER_LEVEL_REVIEW",
     "veteran_last_name" => "Smith",
     "veteran_first_name" => "John",

--- a/spec/factories/decision_review_updated/decision_review_updated.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated.rb
@@ -7101,6 +7101,7 @@ def base_review_issue
     "prior_decision_rating_profile_date" => "2017-02-07T07:21:24+00:00",
     "source_claim_id_for_remand" => nil,
     "source_contention_id_for_remand" => nil,
+    "original_caseflow_request_issue_id" => nil,
     "removed" => false,
     "withdrawn" => false,
     "decision" => nil

--- a/spec/factories/decision_review_updated/decision_review_updated.rb
+++ b/spec/factories/decision_review_updated/decision_review_updated.rb
@@ -7037,6 +7037,7 @@ end
 
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/PerceivedComplexity
+# rubocop:disable Metrics/AbcSize
 def base_message_payload(**args)
   {
     "claim_id" => Faker::Number.number(digits: 7),
@@ -7079,6 +7080,7 @@ def base_message_payload(**args)
 end
 # rubocop:enable Metrics/CyclomaticComplexity
 # rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Metrics/AbcSize
 
 def base_review_issue
   {

--- a/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
@@ -930,8 +930,12 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
 
   describe "#create_decision_type_messages(issue_type, code)" do
     subject { decision_review_created_events.send(:create_decision_type_messages, issue_type, code) }
-    let(:original_dri_prior_decision_type) { decision_review_created.decision_review_issues_created.first.prior_decision_type }
-    let(:original_dri_prior_decision_text) { decision_review_created.decision_review_issues_created.first.prior_decision_text }
+    let(:original_dri_prior_decision_type) do
+      decision_review_created.decision_review_issues_created.first.prior_decision_type
+    end
+    let(:original_dri_prior_decision_text) do
+      decision_review_created.decision_review_issues_created.first.prior_decision_text
+    end
 
     it "creates a message for each prior decision type in the NONRATING_DECISION_TYPES array" do
       expect(subject.count).to eq(34)
@@ -954,12 +958,15 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
     let(:decision_type) { "Accrued" }
     let(:all_decision_review_issues_created) { subject.decision_review_issues_created.all? }
 
-    it "changes the decision_review_issues_created to have a prior_decision_type matching the decision type passed in" do
+    it "changes the decision_review_issues_created to have a prior_decision_type matching the decision type"\
+    " passed in" do
       expect(all_decision_review_issues_created { |issue| issue.prior_decision_type == decision_type }).to eq true
     end
 
-    it "changes the decision_review_issues_created to have a prior_decision_text that includes the decision type passed in" do
-      expect(all_decision_review_issues_created { |issue| issue.prior_decision_text.include?(decision_type) }).to eq true
+    it "changes the decision_review_issues_created to have a prior_decision_text that includes the decision type" \
+    " passed in" do
+      expect(all_decision_review_issues_created { |issue| issue.prior_decision_text.include?(decision_type) })
+        .to eq true
     end
   end
 

--- a/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_created_events_spec.rb
@@ -584,13 +584,13 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
 
   describe "#create_contested_issue(issue_type, code)" do
     subject { decision_review_created_events.send(:create_contested_issue, issue_type, code) }
-    let(:decision_review_issues) do
-      subject.first.decision_review_issues
+    let(:decision_review_issues_created) do
+      subject.first.decision_review_issues_created
     end
 
     it "creates 1 message with eligibility_result 'CONTESTED'" do
       expect(subject.count).to eq(1)
-      expect(decision_review_issues.all? { |issue| issue.eligibility_result == "CONTESTED" }).to eq true
+      expect(decision_review_issues_created.all? { |issue| issue.eligibility_result == "CONTESTED" }).to eq true
     end
   end
 
@@ -906,44 +906,44 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
   describe "#create_eligible_with_two_issues(issue_type, code)" do
     subject { decision_review_created_events.send(:create_eligible_with_two_issues, issue_type, code) }
 
-    it "returns a message with 2 issues in the decision_review_issues array" do
-      expect(subject.first.decision_review_issues.count).to eq(2)
+    it "returns a message with 2 issues in the decision_review_issues_created array" do
+      expect(subject.first.decision_review_issues_created.count).to eq(2)
     end
   end
 
   describe "#create_contested_with_additional_issue(issue_type, code)" do
     subject { decision_review_created_events.send(:create_contested_with_additional_issue, issue_type, code) }
-    let(:decision_review_issues) { subject.first.decision_review_issues }
+    let(:decision_review_issues_created) { subject.first.decision_review_issues_created }
 
-    it "returns a message with 2 issues in the decision_review_issues array" do
-      expect(subject.first.decision_review_issues.count).to eq(2)
+    it "returns a message with 2 issues in the decision_review_issues_created array" do
+      expect(subject.first.decision_review_issues_created.count).to eq(2)
     end
 
     it "one of the decision review issues has eligibility_result 'CONTESTED'" do
-      expect(decision_review_issues.count { |issue| issue.eligibility_result == "CONTESTED" }).to eq(1)
+      expect(decision_review_issues_created.count { |issue| issue.eligibility_result == "CONTESTED" }).to eq(1)
     end
 
     it "one of the decision review issues has eligibility_result that is NOT 'CONTESTED'" do
-      expect(decision_review_issues.count { |issue| issue.eligibility_result != "CONTESTED" }).to eq(1)
+      expect(decision_review_issues_created.count { |issue| issue.eligibility_result != "CONTESTED" }).to eq(1)
     end
   end
 
   describe "#create_decision_type_messages(issue_type, code)" do
     subject { decision_review_created_events.send(:create_decision_type_messages, issue_type, code) }
-    let(:original_dri_prior_decision_type) { decision_review_created.decision_review_issues.first.prior_decision_type }
-    let(:original_dri_prior_decision_text) { decision_review_created.decision_review_issues.first.prior_decision_text }
+    let(:original_dri_prior_decision_type) { decision_review_created.decision_review_issues_created.first.prior_decision_type }
+    let(:original_dri_prior_decision_text) { decision_review_created.decision_review_issues_created.first.prior_decision_text }
 
     it "creates a message for each prior decision type in the NONRATING_DECISION_TYPES array" do
       expect(subject.count).to eq(34)
     end
 
     it "changes each message's prior_decision_type to include the decision type being mapped over" do
-      expect(subject.all? { |dr| dr.decision_review_issues.first.prior_decision_type })
+      expect(subject.all? { |dr| dr.decision_review_issues_created.first.prior_decision_type })
         .not_to eq(original_dri_prior_decision_type)
     end
 
     it "changes each message's prior_decision_text to include the decision text being mapped over" do
-      expect(subject.all? { |dr| dr.decision_review_issues.first.prior_decision_text })
+      expect(subject.all? { |dr| dr.decision_review_issues_created.first.prior_decision_text })
         .not_to eq(original_dri_prior_decision_text)
     end
   end
@@ -952,14 +952,14 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
     subject { decision_review_created_events.send(:change_issue_decision_type_and_decision_text, dr, decision_type) }
     let(:dr) { decision_review_created }
     let(:decision_type) { "Accrued" }
-    let(:all_decision_review_issues) { subject.decision_review_issues.all? }
+    let(:all_decision_review_issues_created) { subject.decision_review_issues_created.all? }
 
-    it "changes the decision_review_issues to have a prior_decision_type matching the decision type passed in" do
-      expect(all_decision_review_issues { |issue| issue.prior_decision_type == decision_type }).to eq true
+    it "changes the decision_review_issues_created to have a prior_decision_type matching the decision type passed in" do
+      expect(all_decision_review_issues_created { |issue| issue.prior_decision_type == decision_type }).to eq true
     end
 
-    it "changes the decision_review_issues to have a prior_decision_text that includes the decision type passed in" do
-      expect(all_decision_review_issues { |issue| issue.prior_decision_text.include?(decision_type) }).to eq true
+    it "changes the decision_review_issues_created to have a prior_decision_text that includes the decision type passed in" do
+      expect(all_decision_review_issues_created { |issue| issue.prior_decision_text.include?(decision_type) }).to eq true
     end
   end
 
@@ -1132,13 +1132,13 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
   describe "#convert_and_format_message(message)" do
     subject { decision_review_created_events.send(:convert_and_format_message, message) }
     let(:message) { decision_review_created }
-    let(:decision_review_issues) { message.decision_review_issues }
-    let(:converted_and_formatted_decision_review_issues) do
-      subject["decisionReviewIssues"]
+    let(:decision_review_issues_created) { message.decision_review_issues_created }
+    let(:converted_and_formatted_decision_review_issues_created) do
+      subject["decisionReviewIssuesCreated"]
     end
 
     let(:not_converted_dri_values) do
-      decision_review_issues.map do |not_converted_issue|
+      decision_review_issues_created.map do |not_converted_issue|
         {
           contention_id: not_converted_issue.contention_id,
           prior_rating_decision_id: not_converted_issue.prior_rating_decision_id,
@@ -1153,7 +1153,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
     end
 
     let(:converted_dri_values) do
-      converted_and_formatted_decision_review_issues.map do |converted_issue|
+      converted_and_formatted_decision_review_issues_created.map do |converted_issue|
         {
           contention_id: converted_issue["contentionId"],
           prior_rating_decision_id: converted_issue["priorRatingDecisionId"],
@@ -1194,7 +1194,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
       expect(subject["intakeCreationTime"].class).to eq(Integer)
       expect(subject["claimCreationTime"].class).to eq(Integer)
 
-      converted_and_formatted_decision_review_issues.each do |issue|
+      converted_and_formatted_decision_review_issues_created.each do |issue|
         expect(issue["priorDecisionNotificationDate"].class).to eq(Integer)
       end
     end
@@ -1213,7 +1213,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
       expect(subject.intake_creation_time.class).to eq(Integer)
       expect(subject.claim_creation_time.class).to eq(Integer)
 
-      subject.decision_review_issues.each do |issue|
+      subject.decision_review_issues_created.each do |issue|
         expect(issue.prior_decision_date.class).to eq(Integer)
       end
     end
@@ -1281,7 +1281,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
   describe "#convert_decision_review_issue_attrs(issue)" do
     subject { decision_review_created_events.send(:convert_decision_review_issue_attrs, issue) }
 
-    let(:issue) { decision_review_created.decision_review_issues.first }
+    let(:issue) { decision_review_created.decision_review_issues_created.first }
 
     it "converts string dates to an integer" do
       subject

--- a/spec/lib/kafka_message_generators/decision_review_updated_events_spec.rb
+++ b/spec/lib/kafka_message_generators/decision_review_updated_events_spec.rb
@@ -89,6 +89,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
 
   describe "#create_dre_message(trait, ep_code)" do
     subject { decision_review_updated_events }
+    let(:original_source) { "originalSource" }
     let(:claimant_participant_id) { "claimantParticipantId" }
     let(:contention_action) { "contentionAction" }
     let(:contention_id) { "contentionId" }
@@ -96,6 +97,7 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
     let(:ep_code_category) { "epCodeCategory" }
     let(:informal_conference_requested) { "informalConferenceRequested" }
     let(:legacy_appeal_id) { "legacyAppealId" }
+    let(:original_caseflow_request_issue_id) { "originalCaseflowRequestIssueId" }
     let(:prior_non_rating_decision_id) { "priorNonRatingDecisionId" }
     let(:prior_decision_rating_profile_date) { "priorDecisionRatingProfileDate" }
     let(:prior_decision_text) { "priorDecisionText" }
@@ -669,6 +671,45 @@ describe KafkaMessageGenerators::DecisionReviewEvents do
         expect(fm_issues_updated[contention_id]).to eq(710_000_002)
         expect(fm_issues_updated[reason_for_contention_action]).to eq("INELIGIBLE_REASON_CHANGED")
         expect(fm_issues_updated[prior_decision_text]).to eq("Service connection for tetnus denied")
+        expect(fm_issues_removed[contention_action]).to eq("DELETE_CONTENTION")
+        expect(fm_issues_removed[contention_id]).to eq(710_000_001)
+        expect(fm_issues_removed[reason_for_contention_action]).to eq("REMOVED_SELECTED")
+        expect(fm_issues_withdrawn[contention_action]).to eq("DELETE_CONTENTION")
+        expect(fm_issues_withdrawn[contention_id]).to eq(710_000_003)
+        expect(fm_issues_withdrawn[reason_for_contention_action]).to eq("WITHDRAWN_SELECTED")
+        expect(fm_issues_not_changed[contention_action]).to eq("NONE")
+        expect(fm_issues_not_changed[contention_id]).to eq(710_000_000)
+        expect(fm_issues_not_changed[reason_for_contention_action]).to eq("NO_CHANGES")
+      end
+    end
+
+    context "creates Decision Review Updated ineligible_rating_hlr_pending_supplemental message from" \
+     " CASEFLOW" do
+      let(:trait) { "ineligible_rating_hlr_pending_supplemental" }
+      let(:ep_code) { "930AMAHDERCL" }
+      let(:topic) { ENV["DECISION_REVIEW_UPDATED_TOPIC"] }
+      it "correct data points for scenario: INELIGIBLE_REASON_CHANGED" do
+        message = subject.send(:create_dre_message, trait, ep_code)
+        formatted_message = subject.send(:convert_and_format_message, message)
+        fm_issues_created = formatted_message[decision_review_issues_created][0]
+        fm_issues_updated = formatted_message[decision_review_issues_updated][0]
+        fm_issues_removed = formatted_message[decision_review_issues_removed][0]
+        fm_issues_withdrawn = formatted_message[decision_review_issues_withdrawn][0]
+        fm_issues_not_changed = formatted_message[decision_review_issues_not_changed][0]
+        expect(subject.instance_variable_get(:@decision_review_event_type)).to eq("decision_review_updated")
+        expect(formatted_message[veteran_participant_id]).to eq(formatted_message[claimant_participant_id])
+        expect(formatted_message[original_source]).to eq("CASEFLOW")
+        expect(formatted_message[decision_review_type]).to eq("HIGHER_LEVEL_REVIEW")
+        expect(formatted_message[ep_code_category]).to eq("rating")
+        expect(fm_issues_created[prior_decision_rating_profile_date]).to_not be_nil
+        expect(fm_issues_created[contention_action]).to eq("ADD_CONTENTION")
+        expect(fm_issues_created[contention_id]).to eq(720_000_000)
+        expect(fm_issues_created[reason_for_contention_action]).to eq("NEW_ELIGIBLE_ISSUE")
+        expect(fm_issues_updated[contention_action]).to eq("NONE")
+        expect(fm_issues_updated[contention_id]).to eq(710_000_002)
+        expect(fm_issues_updated[reason_for_contention_action]).to eq("INELIGIBLE_REASON_CHANGED")
+        expect(fm_issues_updated[prior_decision_text]).to eq("Service connection for tetnus denied")
+        expect(fm_issues_updated[original_caseflow_request_issue_id]).to eq(123_45)
         expect(fm_issues_removed[contention_action]).to eq("DELETE_CONTENTION")
         expect(fm_issues_removed[contention_id]).to eq(710_000_001)
         expect(fm_issues_removed[reason_for_contention_action]).to eq("REMOVED_SELECTED")

--- a/spec/models/builders/base_request_issue_builder_spec.rb
+++ b/spec/models/builders/base_request_issue_builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Builders::BaseRequestIssueCollectionBuilder, type: :model do
   let(:event) { create(:decision_review_created_event, message_payload: decision_review_model.to_json) }
   let(:event_id) { event.id }
   let(:decision_review_model) { build(:decision_review_created) }
-  let(:issue) { decision_review_model.decision_review_issues.first }
+  let(:issue) { decision_review_model.decision_review_issues_created.first }
   let(:bis_rating_profiles) { nil }
   let(:request_issue) { DecisionReviewCreated::RequestIssue.new }
 

--- a/spec/models/builders/base_request_issue_collection_builder_spec.rb
+++ b/spec/models/builders/base_request_issue_collection_builder_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Builders::BaseRequestIssueCollectionBuilder, type: :model do
 
   describe "#_build_request_issue" do
     it "raises a NotImplementedError when it is NOT defined in an inherited class" do
-      expect { fake_child_class.send(:build_request_issue, decision_review_model.decision_review_issues.first, 0) }
-        .to raise_error(NotImplementedError, /must implement the build_request_issue method/)
+      expect do
+        fake_child_class.send(:build_request_issue, decision_review_model.decision_review_issues_created.first, 0)
+      end.to raise_error(NotImplementedError, /must implement the build_request_issue method/)
     end
   end
 end

--- a/spec/models/builders/decision_review_created/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/dto_builder_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
     "decision_review_issues" =>
       [
         {
+          "decision_review_issue_id" => 777,
           "contention_id" => 123_456_789,
           "associated_caseflow_request_issue_id" => nil,
           "unidentified" => false,
@@ -52,6 +53,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
           "legacy_appeal_issue_id" => nil
         },
         {
+          "decision_review_issue_id" => 778,
           "contention_id" => 987_654_321,
           "associated_caseflow_request_issue_id" => nil,
           "unidentified" => false,

--- a/spec/models/builders/decision_review_created/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/dto_builder_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
     "actor_station" => "101",
     "actor_application" => "PASYSACCTCREATE",
     "auto_remand" => false,
-    "decision_review_issues" =>
+    "decision_review_issues_created" =>
       [
         {
           "decision_review_issue_id" => 777,

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -5,7 +5,7 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
   let(:event_id) { event.id }
   let!(:event_audit_without_note) { create(:event_audit, event: event, status: :in_progress) }
   let(:decision_review_model) { build(:decision_review_created) }
-  let(:issue) { decision_review_model.decision_review_issues.first }
+  let(:issue) { decision_review_model.decision_review_issues_created.first }
   let(:builder) { described_class.new(issue, decision_review_model, bis_rating_profiles) }
   let(:bis_rating_profiles) { nil }
   let(:prior_decision_date_converted_to_logical_type) do
@@ -67,7 +67,7 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
     end
 
     it "initializes an issue instance variable" do
-      expect(builder.issue).to be_an_instance_of(DecisionReviewIssue)
+      expect(builder.issue).to be_an_instance_of(DecisionReviewIssueCreated)
     end
 
     it "initializes a new Request Issue instance" do

--- a/spec/models/builders/decision_review_created/request_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_collection_builder_spec.rb
@@ -225,20 +225,6 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
     end
   end
 
-  describe "#handle_no_issues_after_removing_contested" do
-    subject { builder.send(:handle_no_issues_after_removing_contested) }
-    let(:error) { AppealsConsumer::Error::RequestIssueCollectionBuildError }
-    let(:error_msg) do
-      "Failed building from #{described_class} for "\
-      "DecisionReview Claim ID: #{claim_id} does not contain any valid issues after "\
-      "removing 'CONTESTED' ineligible issues"
-    end
-
-    it "raises error AppealsConsumer::Error::RequestIssueCollectionBuildError with message" do
-      expect { subject }.to raise_error(error, error_msg)
-    end
-  end
-
   describe "#build_request_issue(issue, index)" do
     subject { builder.send(:build_request_issue, issue, index) }
 

--- a/spec/models/builders/decision_review_created/request_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_collection_builder_spec.rb
@@ -5,11 +5,11 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
   let(:event_id) { event.id }
   let!(:event_audit_without_note) { create(:event_audit, event: event, status: :in_progress) }
   let(:decision_review_model) { build(:decision_review_created) }
-  let(:decision_review_issues) { decision_review_model.decision_review_issues }
+  let(:decision_review_issues_created) { decision_review_model.decision_review_issues_created }
   let(:request_issues) { described_class.build(decision_review_model) }
   let(:builder) { described_class.new(decision_review_model) }
-  let(:index) { decision_review_issues.index(issue) }
-  let(:issue) { decision_review_issues.first }
+  let(:index) { decision_review_issues_created.index(issue) }
+  let(:issue) { decision_review_issues_created.first }
   let(:claim_id) { decision_review_model.claim_id }
 
   before do
@@ -21,8 +21,8 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
       expect(builder).to be_an_instance_of(Builders::DecisionReviewCreated::RequestIssueCollectionBuilder)
     end
 
-    it "returns an array of DecisionReviewCreated::RequestIssue(s) issue in the decision_review_issues array" do
-      expect(request_issues.count).to eq(decision_review_issues.count)
+    it "returns an array of DecisionReviewCreated::RequestIssue(s) issue in the decision_review_issues_created array" do
+      expect(request_issues.count).to eq(decision_review_issues_created.count)
       expect(request_issues).to all(be_an_instance_of(DecisionReviewCreated::RequestIssue))
     end
   end
@@ -87,7 +87,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
       context "when @earliest_issue_profile_date or @latest_issue_profile_date_plus_one_day return nil" do
         before do
-          decision_review_issues.each do |issue|
+          decision_review_issues_created.each do |issue|
             issue.prior_decision_rating_profile_date = nil
           end
         end
@@ -122,7 +122,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
     subject { builder.fetch_and_set_bis_rating_profiles }
     context "when @earliest_issue_profile_date or @latest_issue_profile_date_plus_one_day return nil" do
       before do
-        decision_review_issues.each do |issue|
+        decision_review_issues_created.each do |issue|
           issue.prior_decision_rating_profile_date = nil
         end
       end
@@ -145,7 +145,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
       build(:decision_review_created, :ineligible_nonrating_hlr_contested_with_additional_issue)
     end
 
-    it "maps valid decision_review_issues into an array of DecisionReviewCreated::RequestIssue(s)" do
+    it "maps valid decision_review_issues_created into an array of DecisionReviewCreated::RequestIssue(s)" do
       expect(subject).to all(be_an_instance_of(DecisionReviewCreated::RequestIssue))
       expect(subject).to be_an_instance_of(Array)
     end
@@ -159,8 +159,8 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
     end
 
     it "returns an array of DecisionReviewIssue(s)" do
-      expect(subject).to all(be_an_instance_of(DecisionReviewIssue))
-      expect(subject.count).to eq(decision_review_issues.count)
+      expect(subject).to all(be_an_instance_of(DecisionReviewIssueCreated))
+      expect(subject.count).to eq(decision_review_issues_created.count)
     end
   end
 
@@ -305,7 +305,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
         issue.contention_id = nil
       end
 
-      it "returns 'Issue Index: decision_review_issues.index(issue)" do
+      it "returns 'Issue Index: decision_review_issues_created.index(issue)" do
         expect(subject).to eq("Issue Index: #{index}")
       end
     end
@@ -317,7 +317,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when valid_issue_profile_dates returns nil" do
       before do
-        decision_review_issues.each do |issue|
+        decision_review_issues_created.each do |issue|
           issue.prior_decision_rating_profile_date = nil
         end
       end
@@ -329,7 +329,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when valid_issue_profile_dates is not-nil" do
       it "returns the earliest decision_review_issue.prior_decision_rating_profile_date converted to Date" do
-        expect(subject).to eq(decision_review_issues.first.prior_decision_rating_profile_date.to_date)
+        expect(subject).to eq(decision_review_issues_created.first.prior_decision_rating_profile_date.to_date)
       end
     end
   end
@@ -340,7 +340,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when valid_issue_profile_dates returns nil" do
       before do
-        decision_review_issues.each do |issue|
+        decision_review_issues_created.each do |issue|
           issue.prior_decision_rating_profile_date = nil
         end
       end
@@ -352,7 +352,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when valid_issue_profile_dates is not-nil" do
       it "returns the latest decision_review_issue.prior_decision_rating_profile_date converted to Date" do
-        expect(subject).to eq(decision_review_issues.last.prior_decision_rating_profile_date.to_date)
+        expect(subject).to eq(decision_review_issues_created.last.prior_decision_rating_profile_date.to_date)
       end
     end
   end
@@ -363,7 +363,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when latest_issue_profile_date returns nil" do
       before do
-        decision_review_issues.each do |issue|
+        decision_review_issues_created.each do |issue|
           issue.prior_decision_rating_profile_date = nil
         end
       end
@@ -375,7 +375,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
 
     context "when latest_issue_profile_date does not return nil" do
       it "returns latest_issue_profile_date plus one day" do
-        expect(subject).to eq(decision_review_issues.last.prior_decision_rating_profile_date.to_date + 1)
+        expect(subject).to eq(decision_review_issues_created.last.prior_decision_rating_profile_date.to_date + 1)
       end
     end
   end
@@ -387,7 +387,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
       let(:decision_review_model) { build(:decision_review_created, :eligible_rating_hlr_with_two_issues) }
       context "when all valid_issues have nil for prior_decision_rating_profile_date" do
         before do
-          decision_review_issues.each do |issue|
+          decision_review_issues_created.each do |issue|
             issue.prior_decision_rating_profile_date = nil
           end
         end
@@ -400,7 +400,7 @@ describe Builders::DecisionReviewCreated::RequestIssueCollectionBuilder do
       context "when valid_issues has at least one not-nil value for prior_decision_rating_profile_date" do
         context "when there are nil values within profile_dates" do
           before do
-            decision_review_issues.first.prior_decision_rating_profile_date = nil
+            decision_review_issues_created.first.prior_decision_rating_profile_date = nil
           end
 
           it "removes the nil values" do

--- a/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/ineligible_to_ineligible_issue_collection_builder_spec.rb
@@ -72,6 +72,22 @@ describe Builders::DecisionReviewUpdated::IneligibleToIneligibleIssueCollectionB
           expect(issue.reason_for_contention_action).not_to eq("PRIOR_DECISION_TEXT_CHANGED")
           expect(issue.reason_for_contention_action).to eq(subject.send(:ineligible_reason_changed))
           expect(issue.contention_action).to eq(subject.send(:no_contention_action))
+          expect(issue.original_caseflow_request_issue_id).to eq(nil)
+        end
+      end
+    end
+
+    context "When decision review updated issues that originated from caseflow" do
+      before do
+        message_payload["original_source"] = "CASEFLOW"
+        message_payload["decision_review_issues_updated"][3]["original_caseflow_request_issue_id"] =
+          123_45
+      end
+      it "builds correct datapoints for an issue that originated from Caseflow" do
+        subject.ineligible_to_ineligible_issues.each do |issue|
+          expect(issue.reason_for_contention_action).to eq(subject.send(:ineligible_reason_changed))
+          expect(issue.contention_action).to eq(subject.send(:no_contention_action))
+          expect(issue.original_caseflow_request_issue_id).to eq(123_45)
         end
       end
     end

--- a/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
@@ -72,8 +72,8 @@ describe Builders::DecisionReviewUpdated::RequestIssueBuilder do
   end
 
   describe "#assign_methods" do
-    it "calls assign_decision_review_issue_id" do
-      expect(builder).to receive(:assign_decision_review_issue_id)
+    it "calls assign_original_caseflow_request_issue_id" do
+      expect(builder).to receive(:assign_original_caseflow_request_issue_id)
       builder.send(:assign_methods)
     end
   end

--- a/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
@@ -119,4 +119,19 @@ describe Builders::DecisionReviewUpdated::RequestIssueBuilder do
       end
     end
   end
+
+  describe "#calculate_rating_issue_associated_at" do
+    subject { builder.send(:calculate_rating_issue_associated_at) }
+
+    before do
+      allow(builder).to receive(:rating?).and_return(true)
+      allow(builder).to receive(:eligible?).and_return(true)
+    end
+    context "when popuating eligible rating issues" do
+      it "#update_time_converted_to_time_ms" do
+        subject
+        expect(builder.send(:update_time_converted_to_timestamp_ms)).to eq(164_108_160_000_0)
+      end
+    end
+  end
 end

--- a/spec/models/virtual/decision_review_created/request_issue_spec.rb
+++ b/spec/models/virtual/decision_review_created/request_issue_spec.rb
@@ -3,7 +3,7 @@
 describe DecisionReviewCreated::RequestIssue do
   let(:event_id) { 44_349 }
   let(:decision_review_created_model) { FactoryBot.build(:decision_review_created) }
-  let(:issue) { decision_review_created_model.decision_review_issues.first }
+  let(:issue) { decision_review_created_model.decision_review_issues_created.first }
   let(:bis_rating_profiles) { nil }
   let(:request_issue) do
     Builders::DecisionReviewCreated::RequestIssueBuilder.build(

--- a/spec/models/virtual/transformers/decision_review_created_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_created_spec.rb
@@ -36,13 +36,13 @@ describe Transformers::DecisionReviewCreated do
         expect(subject.actor_username).to eq("BVADWISE101")
         expect(subject.actor_station).to eq("101")
         expect(subject.actor_application).to eq("PASYSACCTCREATE")
-        expect(subject.decision_review_issues.size).to eq(2)
+        expect(subject.decision_review_issues_created.size).to eq(2)
         expect(subject.event_id).to eq(13)
       end
 
       it "initializes DecisionReviewIssue objects for every obj in issues_array" do
-        subject.decision_review_issues.each do |issue|
-          expect(issue).to be_an_instance_of(DecisionReviewIssue)
+        subject.decision_review_issues_created.each do |issue|
+          expect(issue).to be_an_instance_of(DecisionReviewIssueCreated)
 
           # this additional logic of checking the issues by contention_id enables us to not rely on the index each
           # DecisionReviewIssue is stored at since the index order could change when Github Actions runs
@@ -143,57 +143,61 @@ describe Transformers::DecisionReviewCreated do
       end
 
       context "because decision_review_issues is an empty array" do
-        let(:message_payload_without_decision_review_issues) do
-          build(:decision_review_created, :without_decision_review_issues)
+        let(:message_payload_without_decision_review_issues_created) do
+          build(:decision_review_created, :without_decision_review_issues_created)
         end
 
         it "raises ArgumentError with message: Transformers::DecisionReviewCreated: Message payload must include at "\
         "least one decision review issue" do
           error_message = "Transformers::DecisionReviewCreated: Message payload must include at least one decision "\
-          "review issue"
-          expect { message_payload_without_decision_review_issues }.to raise_error(ArgumentError, error_message)
+          "review issue created"
+          expect { message_payload_without_decision_review_issues_created }.to raise_error(ArgumentError, error_message)
         end
       end
     end
 
     context "when DecisionReviewIssue portion of message_payload is invalid" do
       context "because payload is nil" do
-        let(:message_payload_with_nil_issue) { build(:decision_review_created, :with_nil_decision_review_issue) }
+        let(:message_payload_with_nil_issue) do
+          build(:decision_review_created, :with_nil_decision_review_issue_created)
+        end
 
         it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "DecisionReviewIssue: Message payload cannot be empty or nil"
+          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
           expect { message_payload_with_nil_issue }.to raise_error(ArgumentError, error_message)
         end
       end
 
       context "because payload is empty" do
-        let(:message_payload_with_empty_issue) { build(:decision_review_created, :with_empty_decision_review_issue) }
+        let(:message_payload_with_empty_issue) do
+          build(:decision_review_created, :with_empty_decision_review_issue_created)
+        end
 
         it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "DecisionReviewIssue: Message payload cannot be empty or nil"
+          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
           expect { message_payload_with_empty_issue }.to raise_error(ArgumentError, error_message)
         end
       end
 
       context "because payload has invalid attribute name(s)" do
         let(:message_payload_with_invalid_issue_attr_name) do
-          build(:decision_review_created, :with_invalid_decision_review_issue_attribute_name)
+          build(:decision_review_created, :with_invalid_decision_review_issue_created_attribute_name)
         end
 
         it "raises ArgumentError with message: class_name: Unknown attributes - unknown_attributes" do
-          error_message = "DecisionReviewIssue: Unknown attributes - invalid_attribute"
+          error_message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute"
           expect { message_payload_with_invalid_issue_attr_name }.to raise_error(ArgumentError, error_message)
         end
       end
 
       context "because payload has invalid attribute data type(s)" do
         let(:message_payload_with_invalid_issue_data_type) do
-          build(:decision_review_created, :with_invalid_decision_review_issue_data_type)
+          build(:decision_review_created, :with_invalid_decision_review_issue_created_data_type)
         end
 
         it "raises ArgumentError with message: class_name: name must be one of the allowed types -, got class." do
-          error_message = "DecisionReviewIssue: decision_review_issue_id must be one of the allowed types - [Integer],"\
-           " got String"
+          error_message = "DecisionReviewIssueCreated: decision_review_issue_id must be one of the allowed types -" \
+           " [Integer], got String"
           expect { message_payload_with_invalid_issue_data_type }.to raise_error(ArgumentError, error_message)
         end
       end

--- a/spec/models/virtual/transformers/decision_review_created_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_created_spec.rb
@@ -142,7 +142,7 @@ describe Transformers::DecisionReviewCreated do
         end
       end
 
-      context "because decision_review_issues is an empty array" do
+      context "because decision_review_issues_created is an empty array" do
         let(:message_payload_without_decision_review_issues_created) do
           build(:decision_review_created, :without_decision_review_issues_created)
         end

--- a/spec/models/virtual/transformers/decision_review_created_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_created_spec.rb
@@ -192,8 +192,8 @@ describe Transformers::DecisionReviewCreated do
         end
 
         it "raises ArgumentError with message: class_name: name must be one of the allowed types -, got class." do
-          error_message = "DecisionReviewIssue: contention_id must be one of the allowed types - [Integer, NilClass],"\
-                          " got String"
+          error_message = "DecisionReviewIssue: decision_review_issue_id must be one of the allowed types - [Integer],"\
+           " got String"
           expect { message_payload_with_invalid_issue_data_type }.to raise_error(ArgumentError, error_message)
         end
       end

--- a/spec/models/virtual/transformers/decision_review_updated_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_updated_spec.rb
@@ -109,6 +109,12 @@ describe Transformers::DecisionReviewUpdated do
         end
       end
     end
+    describe "#decision_review_issues" do
+      it "returns all decision_review_issues" do
+        expect(subject.decision_review_issues.count).to eq 10
+        expect(subject.decision_review_issues.class).to eq(Array)
+      end
+    end
   end
 
   context "when invalid" do

--- a/spec/models/virtual/transformers/decision_review_updated_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_updated_spec.rb
@@ -98,6 +98,9 @@ describe Transformers::DecisionReviewUpdated do
           expect(issue.source_claim_id_for_remand).to eq(
             decision_review_issues_updated[index]["source_claim_id_for_remand"]
           )
+          expect(issue.original_caseflow_request_issue_id).to eq(
+            decision_review_issues_updated[index]["original_caseflow_request_issue_id"]
+          )
           expect(issue.source_contention_id_for_remand).to eq(
             decision_review_issues_updated[index]["source_contention_id_for_remand"]
           )

--- a/spec/services/avro_deserializer_service_spec.rb
+++ b/spec/services/avro_deserializer_service_spec.rb
@@ -37,7 +37,7 @@ describe AvroDeserializerService do
       "actor_application" => "PASYSACCTCREATE",
       "informal_conference_tracked_item_id" => "1",
       "auto_remand" => false,
-      "decision_review_issues" => [
+      "decision_review_issues_created" => [
         {
           "decision_review_issue_id" => 777,
           "contention_id" => 123_456_789,

--- a/spec/services/avro_deserializer_service_spec.rb
+++ b/spec/services/avro_deserializer_service_spec.rb
@@ -39,6 +39,7 @@ describe AvroDeserializerService do
       "auto_remand" => false,
       "decision_review_issues" => [
         {
+          "decision_review_issue_id" => 777,
           "contention_id" => 123_456_789,
           "associated_caseflow_request_issue_id" => nil,
           "unidentified" => false,
@@ -67,6 +68,7 @@ describe AvroDeserializerService do
           "prior_decision_source" => nil
         },
         {
+          "decision_review_issue_id" => 777,
           "contention_id" => 987_654_321,
           "associated_caseflow_request_issue_id" => nil,
           "unidentified" => false,

--- a/spec/shared_context/decision_review_updated_context.rb
+++ b/spec/shared_context/decision_review_updated_context.rb
@@ -64,8 +64,8 @@ shared_context "decision_review_updated_context" do
       "prior_decision_award_event_id" => nil,
       "prior_decision_rating_profile_date" => nil,
       "source_claim_id_for_remand" => nil,
-      "original_caseflow_request_issue_id" => nil,
       "source_contention_id_for_remand" => nil,
+      "original_caseflow_request_issue_id" => nil,
       "removed" => false,
       "withdrawn" => false,
       "decision" => nil

--- a/spec/shared_context/decision_review_updated_context.rb
+++ b/spec/shared_context/decision_review_updated_context.rb
@@ -64,6 +64,7 @@ shared_context "decision_review_updated_context" do
       "prior_decision_award_event_id" => nil,
       "prior_decision_rating_profile_date" => nil,
       "source_claim_id_for_remand" => nil,
+      "original_caseflow_request_issue_id" => nil,
       "source_contention_id_for_remand" => nil,
       "removed" => false,
       "withdrawn" => false,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-56484](https://jira.devops.va.gov/browse/APPEALS-56484)

# Description
"As a developer, I need to update the name of the `DecisionReviewIssue` records to `DecisionReviewIssueCreated` so that the appeals-consumer matches the updated naming convention of the `DecisionReviewCreated` topic." 
I also need to update the name of the `DecisionReviewIssues` field to `DecisionReviewIssuesCreated` so that the appeals-consumer matches the updated naming convention of the `DecisionReviewCreated` topic."
I also need to add the `decisionReviewIssueId` field to the `DecisionReviewCreated` AVRO and all related models and builders.
I also need to add `originalCaseflowRequestIssueId` to the Decision Review Updated avro & all related models and model builders.
**Implementation Notes:**
Decision Review Created AVRO: https://github.com/department-of-veterans-affairs/bip-cest-api/blob/development/bip-cest-api/src/main/resources/avros/events/DecisionReviewCreated.avsc
Decision Review Updated AVRO: https://github.com/department-of-veterans-affairs/bip-cest-api/blob/development/bip-cest-api/src/main/resources/avros/events/DecisionReviewUpdated.avsc

## Acceptance Criteria

- [x] The **DecisionReviewIssue** record type will be renamed to **DecisionReviewIssueCreated** within the **DecisionReviewCreated** event. This will require changes to the **DecisionReviewCreated** AVRO and all other relevant **models** and **builders**.
- [x] The **decisionReviewIssues** field of the **DecisionReviewCreated** event will be renamed to **decisionReviewIssuesCreated**. This will require changes to the **DecisionReviewCreated** AVRO and all other relevant **models** and **builders**.
- [x] The **decisionReviewIssueId** field will be added the the **DecisionReviewCreated** event.  This will require changes to the **DecisionReviewCreated** AVRO and all other relevant **models** and **builders**.  This field will have the following characteristics:
- [x] **Datatype**: LONG
- [x] **NON NULLABLE**
- [x] The **originalCaseflowRequestIssueId**{} field will be added the the DecisionReviewUpdated event.  This will require changes to the **DecisionReviewUpdated** AVRO and all other relevant models and builders.
- [x] **Datatype**: LONG
- [x] **NULLABLE**
- [x] The Kafka Message Generator needs to be updated to reflect these changes.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [Test Plan](https://jira.devops.va.gov/browse/APPEALS-58218)
2. [Test Exec Plan](https://jira.devops.va.gov/browse/APPEALS-58261)
3. [Test Exec/Xray](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-58261&testIssueKey=APPEALS-58218)

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
