### PR TITLE
Update #validate_attribute_names method to log unknown attributes

### DIFF
--- a/app/models/builders/base_dto_builder.rb
+++ b/app/models/builders/base_dto_builder.rb
@@ -94,4 +94,9 @@ class Builders::BaseDtoBuilder
   def assign_claimant_email
     @claimant.email
   end
+
+  # This method is used whenever assigning detail_type for any non-DecisionReviewCreated Event.
+  def calculate_and_format_detail_type(decision_review_type)
+    decision_review_type.downcase.camelize
+  end
 end

--- a/app/models/builders/base_request_issue_builder.rb
+++ b/app/models/builders/base_request_issue_builder.rb
@@ -349,8 +349,9 @@ class Builders::BaseRequestIssueBuilder # rubocop:disable Metrics/ClassLength
 
   def handle_associated_request_issue_not_present
     unless associated_caseflow_request_issue_present?
-      fail AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId, "Issue is ineligible due to a pending review"\
-        " but has null for associated_caseflow_request_issue_id"
+      message = "Issue with contention id of #{issue.contention_id} is ineligible due"\
+        " to a pending review but has null for associated_caseflow_request_issue_id"
+      log_msg_and_update_current_event_audit_notes!(message, error: false)
     end
   end
 

--- a/app/models/builders/decision_review_updated/dto_builder.rb
+++ b/app/models/builders/decision_review_updated/dto_builder.rb
@@ -47,7 +47,8 @@ class Builders::DecisionReviewUpdated::DtoBuilder < Builders::BaseDtoBuilder
   def assign_from_decision_review_updated
     @claim_id = @decision_review_updated.claim_id
     @css_id = @decision_review_updated.actor_username
-    @detail_type = @decision_review_updated.decision_review_type
+    # This method is used whenever assigning detail_type for any non-DecisionReviewCreated Event.
+    @detail_type = calculate_and_format_detail_type(@decision_review_updated.decision_review_type)
     @station = @decision_review_updated.actor_station
   end
 

--- a/app/models/concerns/message_payload_validator.rb
+++ b/app/models/concerns/message_payload_validator.rb
@@ -9,7 +9,7 @@ module MessagePayloadValidator
   # Validates attribute names and data types
   def validate(message_payload, class_name)
     validate_presence(message_payload, class_name)
-    validate_attribute_names(message_payload.keys, class_name)
+    log_unknown_attribute_names(message_payload.keys, class_name)
     validate_attribute_data_types(message_payload, class_name)
   end
 
@@ -21,12 +21,12 @@ module MessagePayloadValidator
   end
 
   # Checks that incoming attribute names match the keys listed in class#attribute_types
-  # Fails out of workflow if there is an unknown attribute found
-  def validate_attribute_names(attribute_names, class_name)
+  # If an unknown attribute is found, logs the names of all unknown attributes
+  def log_unknown_attribute_names(attribute_names, class_name)
     unknown_attributes = attribute_names.reject { |attr| attribute_types.key?(attr) }
 
     unless unknown_attributes.empty?
-      fail ArgumentError, "#{class_name}: Unknown attributes - #{unknown_attributes.join(', ')}"
+      Rails.logger.info("#{class_name}: Unknown attributes - #{unknown_attributes.join(', ')}")
     end
   end
 

--- a/app/models/concerns/message_payload_validator.rb
+++ b/app/models/concerns/message_payload_validator.rb
@@ -9,7 +9,7 @@ module MessagePayloadValidator
   # Validates attribute names and data types
   def validate(message_payload, class_name)
     validate_presence(message_payload, class_name)
-    log_unknown_attribute_names(message_payload.keys, class_name)
+    validate_attribute_names(message_payload.keys, class_name)
     validate_attribute_data_types(message_payload, class_name)
   end
 
@@ -22,7 +22,7 @@ module MessagePayloadValidator
 
   # Checks that incoming attribute names match the keys listed in class#attribute_types
   # If an unknown attribute is found, logs the names of all unknown attributes
-  def log_unknown_attribute_names(attribute_names, class_name)
+  def validate_attribute_names(attribute_names, class_name)
     unknown_attributes = attribute_names.reject { |attr| attribute_types.key?(attr) }
 
     unless unknown_attributes.empty?

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -72,7 +72,71 @@ FactoryBot.define do
 
     # START: Payloads that raise error upon DecisionReviewCreated initialization
     trait :invalid_attribute_name do
-      message_payload { { "invalid_attribute" => "invalid" } }
+      message_payload do
+        {
+          "invalid_attribute" => "invalid",
+          "claim_id" => Faker::Number.number(digits: 7),
+          "decision_review_type" => "HIGHER_LEVEL_REVIEW",
+          "veteran_first_name" => "John",
+          "veteran_last_name" => "Smith",
+          "veteran_participant_id" => Faker::Number.number(digits: 9).to_s,
+          "file_number" => Faker::Number.number(digits: 9).to_s,
+          "claimant_participant_id" => Faker::Number.number(digits: 9).to_s,
+          "ep_code" => "030HLRNR",
+          "ep_code_category" => "NON_RATING",
+          "claim_received_date" => "2023-08-25",
+          "claim_lifecycle_status" => "Ready to Work",
+          "payee_code" => "00",
+          "modifier" => "01",
+          "limited_poa_code" => nil,
+          "originated_from_vacols_issue" => false,
+          "informal_conference_requested" => false,
+          "informal_conference_tracked_item_id" => "1",
+          "same_station_review_requested" => false,
+          "intake_creation_time" => Time.zone.now.to_s,
+          "claim_creation_time" => Time.zone.now.to_s,
+          "actor_username" => "BVADWISE101",
+          "actor_station" => "101",
+          "actor_application" => "PASYSACCTCREATE",
+          "auto_remand" => false,
+          "decision_review_issues_created" => decision_review_issues_created
+        }
+      end
+      event_id { nil }
+    end
+
+    trait :multiple_invalid_attribute_names do
+      message_payload do
+        {
+          "invalid_attribute" => "invalid",
+          "second_invalid_attribute" => "second invalid",
+          "claim_id" => Faker::Number.number(digits: 7),
+          "decision_review_type" => "HIGHER_LEVEL_REVIEW",
+          "veteran_first_name" => "John",
+          "veteran_last_name" => "Smith",
+          "veteran_participant_id" => Faker::Number.number(digits: 9).to_s,
+          "file_number" => Faker::Number.number(digits: 9).to_s,
+          "claimant_participant_id" => Faker::Number.number(digits: 9).to_s,
+          "ep_code" => "030HLRNR",
+          "ep_code_category" => "NON_RATING",
+          "claim_received_date" => "2023-08-25",
+          "claim_lifecycle_status" => "Ready to Work",
+          "payee_code" => "00",
+          "modifier" => "01",
+          "limited_poa_code" => nil,
+          "originated_from_vacols_issue" => false,
+          "informal_conference_requested" => false,
+          "informal_conference_tracked_item_id" => "1",
+          "same_station_review_requested" => false,
+          "intake_creation_time" => Time.zone.now.to_s,
+          "claim_creation_time" => Time.zone.now.to_s,
+          "actor_username" => "BVADWISE101",
+          "actor_station" => "101",
+          "actor_application" => "PASYSACCTCREATE",
+          "auto_remand" => false,
+          "decision_review_issues_created" => decision_review_issues_created
+        }
+      end
       event_id { nil }
     end
 
@@ -104,7 +168,78 @@ FactoryBot.define do
     end
 
     trait :with_invalid_decision_review_issue_created_attribute_name do
-      decision_review_issues_created { [{ "invalid_attribute" => "is invalid" }] }
+      decision_review_issues_created do
+        [
+          {
+            "invalid_attribute" => "is invalid",
+            "decision_review_issue_id" => 777,
+            "contention_id" => 123_456_789,
+            "prior_caseflow_decision_issue_id" => nil,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => false,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => 12,
+            "prior_decision_award_event_id" => 17_946,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC",
+            "prior_decision_notification_date" => "2023-08-01",
+            "prior_decision_date" => "2023-08-01",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => nil,
+            "time_override_reason" => nil,
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => nil,
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => nil
+          }
+        ]
+      end
+    end
+
+    trait :with_multiple_invalid_decision_review_issue_created_attribute_names do
+      decision_review_issues_created do
+        [
+          {
+            "invalid_attribute" => "is invalid",
+            "second_invalid_attribute" => "second invalid",
+            "decision_review_issue_id" => 777,
+            "contention_id" => 123_456_789,
+            "prior_caseflow_decision_issue_id" => nil,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => false,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => 12,
+            "prior_decision_award_event_id" => 17_946,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC",
+            "prior_decision_notification_date" => "2023-08-01",
+            "prior_decision_date" => "2023-08-01",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => nil,
+            "time_override_reason" => nil,
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => nil,
+            "source_claim_id_for_remand" => nil,
+            "prior_decision_source" => nil
+          }
+        ]
+      end
     end
 
     trait :with_invalid_decision_review_issue_created_data_type do

--- a/spec/models/builders/base_dto_builder_spec.rb
+++ b/spec/models/builders/base_dto_builder_spec.rb
@@ -130,4 +130,22 @@ RSpec.describe Builders::BaseDtoBuilder, type: :model do
       end
     end
   end
+
+  describe "#calculate_and_format_detail_type" do
+    context "when the decision_review_type from a DecisionReview event is 'HIGHER_LEVEL_REVIEW'" do
+      let(:hlr_decision_review_type) { "HIGHER_LEVEL_REVIEW" }
+      let(:formatted_hlr_decision_review_type) { "HigherLevelReview" }
+
+      it "should return 'HigherLevelReview' formatted in pascal case" do
+        expect(subject.calculate_and_format_detail_type(hlr_decision_review_type)).to eq formatted_hlr_decision_review_type
+      end
+    end
+    context "when the decision_review_type from DecisionReview event is 'SUPPLEMENTAL_CLAIM'" do
+      let(:sc_decision_review_type) { "SUPPLEMENTAL_CLAIM" }
+      let(:formatted_sc_decision_review_type) { "SupplementalClaim" }
+      it "should return 'SupplementalClaim' formatted in pascal case" do
+        expect(subject.calculate_and_format_detail_type(sc_decision_review_type)).to eq formatted_sc_decision_review_type
+      end
+    end
+  end
 end

--- a/spec/models/builders/base_dto_builder_spec.rb
+++ b/spec/models/builders/base_dto_builder_spec.rb
@@ -137,14 +137,16 @@ RSpec.describe Builders::BaseDtoBuilder, type: :model do
       let(:formatted_hlr_decision_review_type) { "HigherLevelReview" }
 
       it "should return 'HigherLevelReview' formatted in pascal case" do
-        expect(subject.calculate_and_format_detail_type(hlr_decision_review_type)).to eq formatted_hlr_decision_review_type
+        expect(subject.calculate_and_format_detail_type(hlr_decision_review_type))
+          .to eq formatted_hlr_decision_review_type
       end
     end
     context "when the decision_review_type from DecisionReview event is 'SUPPLEMENTAL_CLAIM'" do
       let(:sc_decision_review_type) { "SUPPLEMENTAL_CLAIM" }
       let(:formatted_sc_decision_review_type) { "SupplementalClaim" }
       it "should return 'SupplementalClaim' formatted in pascal case" do
-        expect(subject.calculate_and_format_detail_type(sc_decision_review_type)).to eq formatted_sc_decision_review_type
+        expect(subject.calculate_and_format_detail_type(sc_decision_review_type))
+          .to eq formatted_sc_decision_review_type
       end
     end
   end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -460,11 +460,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
 
     context "when the issue is ineligible" do
       context "due to a pending review" do
-        let(:logged_message) do 
-          "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is ineligible due to a pending"\
-          " review but has null for associated_caseflow_request_issue_id"
+        let(:logged_message) do
+          "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is "\
+          "ineligible due to a pending review but has null for associated_caseflow_request_issue_id"
         end
-        let(:note) do 
+        let(:note) do
           "Issue with contention id of 1 is ineligible due to a pending review but has null"\
           " for associated_caseflow_request_issue_id"
         end
@@ -482,13 +482,14 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+            it "logs 'Issue is ineligible due to a pending review "\
+            "but has null for associated_caseflow_request_issue_id'" do
               expect(Rails.logger).to receive(:info).with(logged_message)
-              
+
               subject
             end
 
-            it "updates the 'notes' column on the event_audit with the logged message" do      
+            it "updates the 'notes' column on the event_audit with the logged message" do
               subject
               expect(EventAudit.last.notes).to include(note)
             end
@@ -511,13 +512,14 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+            it "logs 'Issue is ineligible due to a pending review "\
+            "but has null for associated_caseflow_request_issue_id'" do
               expect(Rails.logger).to receive(:info).with(logged_message)
-              
+
               subject
             end
 
-            it "updates the 'notes' column on the event_audit with the logged message" do      
+            it "updates the 'notes' column on the event_audit with the logged message" do
               subject
               expect(EventAudit.last.notes).to include(note)
             end
@@ -540,13 +542,14 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+            it "logs 'Issue is ineligible due to a pending review "\
+            "but has null for associated_caseflow_request_issue_id'" do
               expect(Rails.logger).to receive(:info).with(logged_message)
-              
+
               subject
             end
 
-            it "updates the 'notes' column on the event_audit with the logged message" do      
+            it "updates the 'notes' column on the event_audit with the logged message" do
               subject
               expect(EventAudit.last.notes).to include(note)
             end
@@ -1545,11 +1548,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
 
   describe "#handle_associated_request_issue_not_present" do
     subject { builder.send(:handle_associated_request_issue_not_present) }
-    let(:logged_message) do 
-      "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is ineligible due to a pending"\
-      " review but has null for associated_caseflow_request_issue_id"
+    let(:logged_message) do
+      "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is "\
+      "ineligible due to a pending review but has null for associated_caseflow_request_issue_id"
     end
-    let(:note) do 
+    let(:note) do
       "Issue with contention id of 1 is ineligible due to a pending review but has null"\
       " for associated_caseflow_request_issue_id"
     end
@@ -1563,11 +1566,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
 
       it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
         expect(Rails.logger).to receive(:info).with(logged_message)
-        
+
         subject
       end
 
-      it "updates the 'notes' column on the event_audit with the logged message" do      
+      it "updates the 'notes' column on the event_audit with the logged message" do
         subject
         expect(EventAudit.last.notes).to include(note)
       end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -464,6 +464,10 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
           "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is ineligible due to a pending"\
           " review but has null for associated_caseflow_request_issue_id"
         end
+        let(:note) do 
+          "Issue with contention id of 1 is ineligible due to a pending review but has null"\
+          " for associated_caseflow_request_issue_id"
+        end
         context "when issue.eligibility_result is 'PENDING_HLR'" do
           let(:decision_review_model) { build(:decision_review_created, :ineligible_nonrating_hlr_pending_hlr) }
 
@@ -482,6 +486,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               expect(Rails.logger).to receive(:info).with(logged_message)
               
               subject
+            end
+
+            it "updates the 'notes' column on the event_audit with the logged message" do      
+              subject
+              expect(EventAudit.last.notes).to include(note)
             end
           end
         end
@@ -507,6 +516,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               
               subject
             end
+
+            it "updates the 'notes' column on the event_audit with the logged message" do      
+              subject
+              expect(EventAudit.last.notes).to include(note)
+            end
           end
         end
 
@@ -530,6 +544,11 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               expect(Rails.logger).to receive(:info).with(logged_message)
               
               subject
+            end
+
+            it "updates the 'notes' column on the event_audit with the logged message" do      
+              subject
+              expect(EventAudit.last.notes).to include(note)
             end
           end
         end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -453,15 +453,17 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
   end
 
   describe "#calculate_ineligible_due_to_id" do
+    before do
+      issue.contention_id = 1
+    end
     subject { builder.send(:calculate_ineligible_due_to_id) }
 
     context "when the issue is ineligible" do
       context "due to a pending review" do
-        let(:error) { AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId }
-        let(:error_msg) do
-          "Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id"
+        let(:logged_message) do 
+          "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is ineligible due to a pending"\
+          " review but has null for associated_caseflow_request_issue_id"
         end
-
         context "when issue.eligibility_result is 'PENDING_HLR'" do
           let(:decision_review_model) { build(:decision_review_created, :ineligible_nonrating_hlr_pending_hlr) }
 
@@ -476,8 +478,10 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "raises AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId with message" do
-              expect { subject }.to raise_error(error, error_msg)
+            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+              expect(Rails.logger).to receive(:info).with(logged_message)
+              
+              subject
             end
           end
         end
@@ -498,8 +502,10 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "raises AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId with message" do
-              expect { subject }.to raise_error(error, error_msg)
+            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+              expect(Rails.logger).to receive(:info).with(logged_message)
+              
+              subject
             end
           end
         end
@@ -520,8 +526,10 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
               issue.associated_caseflow_request_issue_id = nil
             end
 
-            it "raises AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId with message" do
-              expect { subject }.to raise_error(error, error_msg)
+            it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+              expect(Rails.logger).to receive(:info).with(logged_message)
+              
+              subject
             end
           end
         end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -1545,25 +1545,31 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
 
   describe "#handle_associated_request_issue_not_present" do
     subject { builder.send(:handle_associated_request_issue_not_present) }
-    let(:error) { AppealsConsumer::Error::NullAssociatedCaseflowRequestIssueId }
-    let(:error_msg) do
-      "Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id"
+    let(:logged_message) do 
+      "[Builders::DecisionReviewCreated::RequestIssueBuilder] Issue with contention id of 1 is ineligible due to a pending"\
+      " review but has null for associated_caseflow_request_issue_id"
+    end
+    let(:note) do 
+      "Issue with contention id of 1 is ineligible due to a pending review but has null"\
+      " for associated_caseflow_request_issue_id"
     end
     let(:decision_review_model) { build(:decision_review_created, :ineligible_nonrating_hlr_pending_board_appeal) }
 
-    context "when there isn't an associated_caseflow_request_issue_id present" do
-      it "does not raise an error" do
-        expect { subject }.not_to raise_error
-      end
-    end
-
-    context "when there is an associated_caseflow_request_issue_id present" do
+    context "when there is not an associated_caseflow_request_issue_id present" do
       before do
+        issue.contention_id = 1
         issue.associated_caseflow_request_issue_id = nil
       end
 
-      it "raises an error" do
-        expect { subject }.to raise_error(error, error_msg)
+      it "logs 'Issue is ineligible due to a pending review but has null for associated_caseflow_request_issue_id'" do
+        expect(Rails.logger).to receive(:info).with(logged_message)
+        
+        subject
+      end
+
+      it "updates the 'notes' column on the event_audit with the logged message" do      
+        subject
+        expect(EventAudit.last.notes).to include(note)
       end
     end
   end

--- a/spec/models/builders/decision_review_updated/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/dto_builder_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Builders::DecisionReviewUpdated::DtoBuilder, type: :model do
 
       expect(dto_builder.instance_variable_get(:@claim_id)).to eq("claim_123")
       expect(dto_builder.instance_variable_get(:@css_id)).to eq("user_123")
-      expect(dto_builder.instance_variable_get(:@detail_type)).to eq("type_123")
+      expect(dto_builder.instance_variable_get(:@detail_type)).to eq("Type123")
       expect(dto_builder.instance_variable_get(:@station)).to eq("station_123")
     end
   end

--- a/spec/models/concerns/message_payload_validator_spec.rb
+++ b/spec/models/concerns/message_payload_validator_spec.rb
@@ -33,10 +33,25 @@ describe MessagePayloadValidator do
 
       context "when there are unexpected attribute name(s)" do
         let(:message_payload_with_invalid_attribute_name) { build(:decision_review_created, :invalid_attribute_name) }
+        let(:message_payload_with_multiple_invalid_names) do
+          build(:decision_review_created, :multiple_invalid_attribute_names)
+        end
 
-        it "raises an ArgumentError with message: class_name: Unknown attributes - unknown_attributes" do
-          error_message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
-          expect { message_payload_with_invalid_attribute_name }.to raise_error(ArgumentError, error_message)
+        context "when there is a single unexpected attribute name" do
+          it "logs the unknown attribute name" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_invalid_attribute_name
+          end
+        end
+
+        context "when there are multiple unexpected attribute names" do
+          it "logs all the unknown attribute names" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute, "\
+            "second_invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_multiple_invalid_names
+          end
         end
       end
 

--- a/spec/models/concerns/message_payload_validator_spec.rb
+++ b/spec/models/concerns/message_payload_validator_spec.rb
@@ -31,7 +31,7 @@ describe MessagePayloadValidator do
         end
       end
 
-      context "because there are invalid attribute name(s)" do
+      context "when there are unexpected attribute name(s)" do
         let(:message_payload_with_invalid_attribute_name) { build(:decision_review_created, :invalid_attribute_name) }
 
         it "raises an ArgumentError with message: class_name: Unknown attributes - unknown_attributes" do

--- a/spec/models/virtual/transformers/decision_review_created_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_created_spec.rb
@@ -123,12 +123,27 @@ describe Transformers::DecisionReviewCreated do
         end
       end
 
-      context "because payload has invalid attribute name(s)" do
+      context "when there are unexpected attribute name(s)" do
         let(:message_payload_with_invalid_attribute_name) { build(:decision_review_created, :invalid_attribute_name) }
+        let(:message_payload_with_multiple_invalid_names) do
+          build(:decision_review_created, :multiple_invalid_attribute_names)
+        end
 
-        it "raises ArgumentError with message: Unknown attributes: unknown_attributes" do
-          error_message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
-          expect { message_payload_with_invalid_attribute_name }.to raise_error(ArgumentError, error_message)
+        context "when there is a single unexpected attribute name" do
+          it "logs the unknown attribute name" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_invalid_attribute_name
+          end
+        end
+
+        context "when there are multiple unexpected attribute names" do
+          it "logs all the unknown attribute names" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute, "\
+            "second_invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_multiple_invalid_names
+          end
         end
       end
 
@@ -183,10 +198,25 @@ describe Transformers::DecisionReviewCreated do
         let(:message_payload_with_invalid_issue_attr_name) do
           build(:decision_review_created, :with_invalid_decision_review_issue_created_attribute_name)
         end
+        let(:message_payload_with_multiple_invalid_issue_attr_names) do
+          build(:decision_review_created, :with_multiple_invalid_decision_review_issue_created_attribute_names)
+        end
 
-        it "raises ArgumentError with message: class_name: Unknown attributes - unknown_attributes" do
-          error_message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute"
-          expect { message_payload_with_invalid_issue_attr_name }.to raise_error(ArgumentError, error_message)
+        context "when there is a single unexpected attribute name" do
+          it "logs the unknown attribute name" do
+            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_invalid_issue_attr_name
+          end
+        end
+
+        context "when there are multiple unexpected attribute names" do
+          it "logs all the unknown attribute names" do
+            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute, "\
+            "second_invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_multiple_invalid_issue_attr_names
+          end
         end
       end
 

--- a/spec/models/virtual/transformers/decision_review_updated_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_updated_spec.rb
@@ -133,6 +133,37 @@ describe Transformers::DecisionReviewUpdated do
         expect { subject }.to raise_error(ArgumentError, error_message)
       end
     end
+
+    context "when there are unexpected attribute name(s)" do
+      let(:message_payload_with_invalid_attr_name) do
+        message_payload.merge({ "invalid_attribute" => "invalid" })
+      end
+      let(:message_payload_with_multiple_invalid_attr_names) do
+        message_payload.merge(
+          {
+            "invalid_attribute" => "invalid",
+            "second_invalid_attribute" => "second invalid"
+          }
+        )
+      end
+
+      context "when there is a single unexpected attribute name" do
+        it "logs the unknown attribute name" do
+          message = "Transformers::DecisionReviewUpdated: Unknown attributes - invalid_attribute"
+          expect(Rails.logger).to receive(:info).with(message)
+          described_class.new(event_id, message_payload_with_invalid_attr_name)
+        end
+      end
+
+      context "when there are multiple unexpected attribute names" do
+        it "logs all the unknown attribute names" do
+          message = "Transformers::DecisionReviewUpdated: Unknown attributes - invalid_attribute, "\
+          "second_invalid_attribute"
+          expect(Rails.logger).to receive(:info).with(message)
+          described_class.new(event_id, message_payload_with_multiple_invalid_attr_names)
+        end
+      end
+    end
   end
 
   context "when a decision exist" do


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60014](https://jira.devops.va.gov/browse/APPEALS-60014)

# Description
Changes the `validate_attribute_names` method in the `MessagePayloadValidator` class. Previously, the functionality of this method was to fail out of the workflow entirely if the message payload contained an attribute that it did not recognize/expect. Now this method will log the name of the unknown/unexpected attribute name and it will no longer fail out of the workflow.

Added new #calculate_and_format_detail_type method to correctly format 'detail_type' for DecisionReviewUpdated event.

Updated #handle_associated_request_issue_not_present to log that associated request issue is not present when it should be rather than raising an error.



## Acceptance Criteria
- [x] Code compiles correctly

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
