### PR TITLE
Add DecisionReviewCompleted call to the Caseflow Service Class in Appeals-Consumer application

### DIFF
--- a/app/services/external_api/caseflow_service.rb
+++ b/app/services/external_api/caseflow_service.rb
@@ -34,6 +34,16 @@ class ExternalApi::CaseflowService
       parse_response(response, payload["claim_id"])
     end
 
+    # Sends request to Caseflow API based on the provided DecisionReviewCompleted DTO Builder
+    # and processes the response from Caseflow.
+    def finalize_records_from_decision_review_completed_event!(decision_review_completed_dto_builder)
+      payload = decision_review_completed_dto_builder.payload
+      headers = build_headers(decision_review_completed_dto_builder)
+      endpoint = "#{BASE_ENDPOINT}decision_review_completed"
+      response = send_caseflow_request(payload, endpoint, headers)
+      parse_response(response, payload["claim_id"])
+    end
+
     private
 
     # Sends a request to the Caseflow API with specified payload, endpoint, and optional headers.


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-59980](https://jira.devops.va.gov/browse/APPEALS-59980)

# Description
Adds `finalize_records_from_decision_review_completed_event!` method to `caseflow_service.rb`.

`finalize_records_from_decision_review_completed_event!`:
- Receives `decision_review_completed_dto_builder` as argument
- Extracts payload from builder, builds headers, and establishes endpoint
- Makes POST request to Caseflow
- Parses response from Caseflow

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Class method will be located in the `app/services/external_api/caseflow_service.rb` directory
- [x] Class method will be named `finalize_records_from_decision_review_completed_event!` to call caseflow and make post request to `api/events/v1/decision_review_completed`
- [x] Class method will accept `decision_review_completed_dto_builder` as a parameter
- [x] Class method will have the following local variable assignment statements:
  - [x] `payload` - this local variable will have an assignment statement populated by passed `decision_review_completed_dto_builder.payload` argument
  - [x] `headers` - this local variable will call on the `build_headers` method and be passed in a parameter called  `decision_review_completed_dto_builder`
  - [x] `endpoint` - this local variable will have an assignment statement populated with:                       `{BASE_ENDPOINT}decision_review_completed`
  - [x] `response` - will call on the `send_caseflow_request` method which will accept the following previously defined local variables as arguments: `payload`, `endpoint`, `headers`
  - [x] `parse_response` - will be returned and accept the following arguments: `response`, `payload["claim_id"]`
- [x] Request and Response (including any errors) will be logged, including duration of start and finish
- [x] Class method will utilize `parse_response` method to handle responses and raise error for any response other than a 200 or 201.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [APPEALS-60400](https://jira.devops.va.gov/browse/APPEALS-60400)
2. [APPEALS-60437](https://jira.devops.va.gov/browse/APPEALS-60437)
3. [Jira Xray](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-60437&testIssueKey=APPEALS-60400)

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

