### PR TITLE
aaron/APPEALS-60761

### DIFF
--- a/app/models/builders/base_request_issue_builder.rb
+++ b/app/models/builders/base_request_issue_builder.rb
@@ -88,6 +88,7 @@ class Builders::BaseRequestIssueBuilder # rubocop:disable Metrics/ClassLength
     assign_nonrating_issue_bgs_id
     assign_type
     assign_decision_review_issue_id
+    assign_veteran_participant_id
   end
 
   def calculate_methods
@@ -577,5 +578,9 @@ class Builders::BaseRequestIssueBuilder # rubocop:disable Metrics/ClassLength
 
   def assign_decision_review_issue_id
     @request_issue.decision_review_issue_id = issue.decision_review_issue_id
+  end
+  
+  def assign_veteran_participant_id
+    @request_issue.veteran_participant_id = decision_review_model.veteran_participant_id
   end
 end

--- a/app/models/builders/base_request_issue_builder.rb
+++ b/app/models/builders/base_request_issue_builder.rb
@@ -579,7 +579,7 @@ class Builders::BaseRequestIssueBuilder # rubocop:disable Metrics/ClassLength
   def assign_decision_review_issue_id
     @request_issue.decision_review_issue_id = issue.decision_review_issue_id
   end
-  
+
   def assign_veteran_participant_id
     @request_issue.veteran_participant_id = decision_review_model.veteran_participant_id
   end

--- a/app/models/virtual/base_request_issue.rb
+++ b/app/models/virtual/base_request_issue.rb
@@ -2,7 +2,7 @@
 
 class BaseRequestIssue
   attr_accessor :contested_issue_description, :contention_reference_id, :contested_rating_decision_reference_id,
-                :contested_rating_issue_profile_date, :contested_rating_issue_reference_id,
+                :contested_rating_issue_profile_date, :contested_rating_issue_reference_id, :veteran_participant_id,
                 :contested_decision_issue_id, :decision_date, :decision_review_issue_id, :ineligible_due_to_id,
                 :ineligible_reason, :is_unidentified, :unidentified_issue_text, :nonrating_issue_category,
                 :nonrating_issue_description, :untimely_exemption, :untimely_exemption_notes, :vacols_id,

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -80,5 +80,5 @@ Rails.application.configure do
   # # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Max failed errors until event is switched to "failed"
-  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "4"
+  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "6"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,7 +70,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   # Max failed errors until event is switched to "failed"
-  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "4"
+  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "6"
 
   config.api_key = "token"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   # Max failed errors until event is switched to "failed"
-  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "4"
+  ENV["MAX_ERRORS_FOR_FAILURE"] ||= "6"
 
   # Dynatrace variables
   ENV["STATSD_ENV"] = "test"

--- a/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_updated/request_issue_builder_spec.rb
@@ -84,6 +84,7 @@ describe Builders::DecisionReviewUpdated::RequestIssueBuilder do
       expect(builder).to receive(:assign_nonrating_issue_bgs_id)
       expect(builder).to receive(:assign_type)
       expect(builder).to receive(:assign_decision_review_issue_id)
+      expect(builder).to receive(:assign_veteran_participant_id)
 
       builder.send(:assign_methods)
     end
@@ -111,6 +112,13 @@ describe Builders::DecisionReviewUpdated::RequestIssueBuilder do
       expect(builder).to receive(:calculate_nonrating_issue_bgs_source)
 
       builder.send(:calculate_methods)
+    end
+  end
+
+  describe "#assign_veteran_participant_id" do
+    subject { builder.send(:assign_veteran_participant_id) }
+    it "assigns the veteran's participant id to the value passed by the event" do
+      expect(subject).to eq(decision_review_updated_model.veteran_participant_id)
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Event, type: :model do
 
     context "when the number of event audits is greater than or equal to MAX_ERRORS_FOR_FAILURE" do
       context "the last three event audits have an error in the error column" do
-        let!(:event_audits) { create_list(:event_audit, 4, event: event, status: "failed") }
+        let!(:event_audits) { create_list(:event_audit, 6, event: event, status: "failed") }
 
         it "event's state should be updated to 'failed'" do
           expect(event.state).to eq("in_progress")


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60761](https://jira.devops.va.gov/browse/APPEALS-60761)

# Description
As a developer, I need to add a new #assign_veteran_participant_id method to the base_request_issue_builder.rb class that will assign the veteran_participant_id to all request issues generated so that Caseflow can properly track which veteran is tied to each request issue.

## Acceptance Criteria
- [x] a method called #assign_veteran_participant_id exist within the base_request_issue_builder.rb class.
- [x] this method assigns the value of veteranParticipantId that is derived from the DecisionReview type events to all request issue generated from these events.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added