### PR TITLE
APPEALS-60773: Update DecisionReviewUpdatedTransformer to allow new Decision Attributes to be nullable

### DIFF
--- a/app/models/virtual/transformers/decision_review_updated.rb
+++ b/app/models/virtual/transformers/decision_review_updated.rb
@@ -189,15 +189,15 @@ class Decision
   DECISION_ATTRIBUTES = {
     "contention_id" => Integer,
     "disposition" => String,
-    "dta_error_explanation" => String,
-    "decision_source" => String,
-    "category" => String,
-    "decision_id" => Integer,
-    "decision_text" => String,
-    "award_event_id" => Integer,
-    "rating_profile_date" => String,
+    "dta_error_explanation" => [String, NilClass],
+    "decision_source" => [String, NilClass],
+    "category" => [String, NilClass],
+    "decision_id" => [Integer, NilClass],
+    "decision_text" => [String, NilClass],
+    "award_event_id" => [Integer, NilClass],
+    "rating_profile_date" => [String, NilClass],
     "decision_recorded_time" => String,
-    "decision_finalized_time" => String
+    "decision_finalized_time" => [String, NilClass]
   }.freeze
 
   DECISION_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }

--- a/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_UPDATED_V01.avsc
+++ b/docker-bin/BIA_SERVICES_BIE_CATALOG_LOCAL_DECISION_REVIEW_UPDATED_V01.avsc
@@ -459,37 +459,65 @@
                       },
                       {
                         "name": "dtaErrorExplanation",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "In the case of a Duty To Assist (DTA) Error disposition, the explanation given by the user as to why a DTA Error disposition was appropriate for the associated contention."
                       },
                       {
                         "name": "decisionSource",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "The source of the decision if it made changes to the corporate record."
                       },
                       {
                         "name": "category",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "The category of the decision based on whether the issue is a Rating or Non-Rating issue. May be blank (unidentified). Can be RATING or NON_RATING"
                       },
                       {
                         "name": "decisionId",
-                        "type": "long",
+                        "type": [
+                          "null",
+                          "long"
+                        ],
+                        "default": null,
                         "doc": "ID of the decision from the source system. (Rating = rbaIssueId from VBMS-R, Non-Rating = decisionId from VBMS-A; null if unidentified or not provided.)"
                       },
                       {
                         "name": "decisionText",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "If the decision originated from VBMS-Ratings, then this is the decision text associated with the issue rated (Ex. Service connection for Burns is granted with an evaluation of 10 percent effective July 3, 2023). If the decision originated from VBMS-Awards, then this is the decision selected for the specific awards benefit type."
                       },
                       {
                         "name": "awardEventId",
-                        "type": "long",
+                        "type": [
+                          "null",
+                          "long"
+                        ],
+                        "default": null,
                         "doc": "The identifier of the contention that was created for this draft decision."
                       },
                       {
                         "name": "ratingProfileDate",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "The profile date of the rating profile from VBMS-R that this decision was made on, for Rating decisions."
                       },
                       {
@@ -499,7 +527,11 @@
                       },
                       {
                         "name": "decisionFinalizedTime",
-                        "type": "string",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null,
                         "doc": "Time at which the issue was finalized. Only set when issue is authorized with a non-deferred disposition."
                       }
                     ]


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60773](https://jira.devops.va.gov/browse/APPEALS-60773)

# Description
As a developer, I need to update the DecsionReviewUpdated Transformer datachecker to match the updated Decision Avro that C & P is using.

## Acceptance Criteria

- [x] Update DecisionReviewUpdated Transformer Decision attributes to match most recent version of Decision Avro.


