### PR TITLE
hotfix/APPEALS-60781

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ coverage
 
 # Ignore byebug history
 .byebug_history
+
+
+# Ignore DS_Store
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,5 @@ coverage
 # Ignore byebug history
 .byebug_history
 
-
 # Ignore DS_Store
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ one-test:
 
 registry:  ## Upload schema AVRO to the Schema Registry
 	docker compose run --rm rails /usr/bin/decision_review_created_schema_registry.sh
-	docker compose run --rm rails /usr/bin//decision_review_updated_schema_registry.sh
+	docker compose run --rm rails /usr/bin/decision_review_updated_schema_registry.sh
 
 run-all-queues: ## start shoryuken with all queues
 	docker compose run --rm rails bundle exec shoryuken -q appeals_consumer_development_high_priority appeals_consumer_development_low_priority -R

--- a/app/jobs/base_event_processing_job.rb
+++ b/app/jobs/base_event_processing_job.rb
@@ -60,11 +60,11 @@ class BaseEventProcessingJob < ApplicationJob
   end
 
   def handle_job_error!(error)
-    log_error
     ActiveRecord::Base.transaction do
       comitted_event_audit&.failed!(error.message)
       @event.handle_failure(error.message)
     end
+    log_error
   end
 
   def set_current_user_to_system_admin

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -15,7 +15,7 @@ class SlackService
   attr_reader :url
 
   def send_notification(msg, title = "", channel = DEFAULT_CHANNEL)
-    return unless url && (aws_env == "uat" || aws_env == "prod")
+    return unless url && (aws_env == "uat" || aws_env == "prodtest" aws_env == "prod")
 
     slack_msg = format_slack_msg(msg, title, channel)
 

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -15,7 +15,7 @@ class SlackService
   attr_reader :url
 
   def send_notification(msg, title = "", channel = DEFAULT_CHANNEL)
-    return unless url && (aws_env == "uat" || aws_env == "prodtest" aws_env == "prod")
+    return unless url && (aws_env == "uat" || aws_env == "prodtest" || aws_env == "prod")
 
     slack_msg = format_slack_msg(msg, title, channel)
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60781](https://jira.devops.va.gov/browse/APPEALS-60781)

# Description
As a developer, I need to ensure that Slack is getting alerted when an Event enters into a state of FAILED so that devops can be alerted of catastrophic failures of an event processing.

## Acceptance Criteria
- [x] Slack is alerted whenever an event's "state" is updated to 'FAILED' during an event processing job.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

### Error Handling
- [x] Slack is alerted whenever an event's "state" in updated to 'FAILED' during an event processing job.