### PR TITLE
Build DecisionReviewCompleted Plain Old Ruby Object Transformer

### DIFF
--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -125,6 +125,8 @@ class DecisionReviewIssueCompleted
   end
 end
 
+# Decision represents an individual decision object from
+# a decision_review_issues_completed's decision field
 class Decision
   include MessagePayloadValidator
 
@@ -144,23 +146,29 @@ class Decision
 
   DECISION_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
 
+  # When Decision.new(decision) is called, this method will validate message_payload
+  # presence, attribute names and data types and assign the incoming attributes to defined keys
   def initialize(decision = {})
     validate(decision, self.class.name)
     assign(decision)
   end
 
+  # Lists the attributes and corresponding data types
   def attribute_types
     DECISION_ATTRIBUTES
   end
 
   private
 
+  # Assigns attributes from issue_attrs to defined keys
   def assign(decision)
     attribute_types.each_key do |attr|
       instance_variable_set("@#{attr}", decision[attr])
     end
   end
 
+  # Overwrites validate_presence method in MessagePayloadValidator because
+  # a DecisionReviewCompleted Decision CAN be nil but not empty
   def validate_presence(decision, class_name)
     if decision.blank?
       fail ArgumentError, "#{class_name}: Message payload cannot be empty"

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -12,14 +12,14 @@ class Transformers::DecisionReviewCompleted
   DECISION_REVIEW_COMPLETED_ATTRIBUTES = {
     "claim_id" => Integer,
     "decision_review_type" => [String, NilClass],
-    "veteran_participant_id" => String,
-    "claimant_participant_id" => String,
+    "veteran_participant_id" => [String, NilClass],
+    "claimant_participant_id" => [String, NilClass],
     "remand_created" => [TrueClass, FalseClass, NilClass],
-    "ep_code_category" => String,
-    "claim_lifecycle_status" => String,
-    "actor_username" => String,
-    "actor_application" => String,
-    "completion_time" => String,
+    "ep_code_category" => [String, NilClass],
+    "claim_lifecycle_status" => [String, NilClass],
+    "actor_username" => [String, NilClass],
+    "actor_application" => [String, NilClass],
+    "completion_time" => [String, NilClass],
     "decision_review_issues_completed" => Array
   }.freeze
   # Allows read and write access for attributes
@@ -74,11 +74,11 @@ class DecisionReviewIssueCompleted
   # Data types are stored in an array when the value isn't limited to one data type
   # For example, soc_opt_in could be a boolean OR nil
   DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES = {
-    "decision_review_issue_id" => [Integer],
+    "decision_review_issue_id" => Integer,
     "contention_id" => [Integer, NilClass],
     "remand_claim_id" => [String, NilClass],
     "remand_contention_id" => [String, NilClass],
-    "unidentified" => [TrueClass, FalseClass],
+    "unidentified" => [TrueClass, FalseClass, NilClass],
     "prior_rating_decision_id" => [Integer, NilClass],
     "prior_non_rating_decision_id" => [Integer, NilClass],
     "prior_caseflow_decision_issue_id" => [Integer, NilClass],

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -40,9 +40,11 @@ class Transformers::DecisionReviewCompleted
     DECISION_REVIEW_COMPLETED_ATTRIBUTES
   end
 
+  private
+
   # Assigns attributes from the message_payload to defined keys
   def assign(message_payload)
-    DECISION_REVIEW_COMPLETED_ATTRIBUTES.each_key do |attr|
+    attribute_types.each_key do |attr|
       instance_variable_set("@#{attr}", message_payload[attr])
     end
 
@@ -102,16 +104,16 @@ class DecisionReviewIssueCompleted
     create_decisions(issue["decision"])
   end
 
-  private
-
   # Lists the attributes and corresponding data types
   def attribute_types
     DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES
   end
 
+  private
+
   # Assigns attributes from issue_attrs to defined keys
   def assign(issue)
-    DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES.each_key do |attr|
+    attribute_types.each_key do |attr|
       instance_variable_set("@#{attr}", issue[attr])
     end
   end
@@ -147,14 +149,14 @@ class Decision
     assign(decision)
   end
 
-  private
-
   def attribute_types
     DECISION_ATTRIBUTES
   end
 
+  private
+
   def assign(decision)
-    DECISION_ATTRIBUTES.each_key do |attr|
+    attribute_types.each_key do |attr|
       instance_variable_set("@#{attr}", decision[attr])
     end
   end

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -121,13 +121,13 @@ class DecisionReviewIssueCompleted
   def create_decisions(decision)
     return if decision.nil?
 
-    @decision = Decision.new(decision)
+    @decision = CompletedDecision.new(decision)
   end
 end
 
-# Decision represents an individual decision object from
+# CompletedDecision represents an individual decision object from
 # a decision_review_issues_completed's decision field
-class Decision
+class CompletedDecision
   include MessagePayloadValidator
 
   DECISION_ATTRIBUTES = {
@@ -146,7 +146,7 @@ class Decision
 
   DECISION_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
 
-  # When Decision.new(decision) is called, this method will validate message_payload
+  # When CompletedDecision.new(decision) is called, this method will validate message_payload
   # presence, attribute names and data types and assign the incoming attributes to defined keys
   def initialize(decision = {})
     validate(decision, self.class.name)
@@ -167,8 +167,8 @@ class Decision
     end
   end
 
-  # Overwrites validate_presence method in MessagePayloadValidator because
-  # a DecisionReviewCompleted Decision CAN be nil but not empty
+  # Overwrites validate_presence method in MessagePayloadValidator because a
+  # DecisionReviewCompleted CompletedDecision CAN be nil but not an empty hash
   def validate_presence(decision, class_name)
     if decision.blank?
       fail ArgumentError, "#{class_name}: Message payload cannot be empty"

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# DecisionReviewCompleted represents the message_payload from an individual DecisionReviewCompletedEvent
+class Transformers::DecisionReviewCompleted
+  include MessagePayloadValidator
+
+  attr_reader :event_id
+
+  # Lists the attributes and corresponding data types
+  # Data types are listed in an array when the value isn't limited to one data type
+  # For example, remand_created could be a boolean OR nil
+  DECISION_REVIEW_COMPLETED_ATTRIBUTES = {
+    "claim_id" => Integer,
+    "decision_review_type" => [String, NilClass],
+    "veteran_participant_id" => String,
+    "claimant_participant_id" => String,
+    "remand_created" => [TrueClass, FalseClass, NilClass],
+    "ep_code_category" => String,
+    "claim_lifecycle_status" => String,
+    "actor_username" => String,
+    "actor_application" => String,
+    "completion_time" => String,
+    "decision_review_issues_completed" => Array
+  }.freeze
+  # Allows read and write access for attributes
+  DECISION_REVIEW_COMPLETED_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
+
+  # When DecisionReviewCompleted.new(message_payload) is called, this method will validate message_payload
+  # presence, attribute names and data types, assign the incoming attributes to defined keys,
+  # and create DecisionReviewIssueCompleted instances for each object in
+  # message_payload's decision_review_issues_completed array
+  def initialize(event_id, message_payload)
+    @event_id = event_id
+    validate(message_payload, self.class.name)
+    assign(message_payload)
+  end
+
+  # Lists the attributes and corresponding data types
+  def attribute_types
+    DECISION_REVIEW_COMPLETED_ATTRIBUTES
+  end
+
+  # Assigns attributes from the message_payload to defined keys
+  def assign(message_payload)
+    DECISION_REVIEW_COMPLETED_ATTRIBUTES.each_key do |attr|
+      instance_variable_set("@#{attr}", message_payload[attr])
+    end
+
+    decision_review_issues_completed_array = message_payload["decision_review_issues_completed"]
+    @decision_review_issues_completed = create_decision_review_issues_completed(decision_review_issues_completed_array)
+  end
+
+  # Creates instances of DecisionReviewIssueCompleted, validates attributes, and assigns attributes
+  # for each object in the decision_review_issues_completed array
+  # Fails out of workflow if decision_review_issues is an empty array
+  def create_decision_review_issues_completed(decision_review_issues_completed)
+    if decision_review_issues_completed.blank?
+      fail ArgumentError,
+           "#{self.class.name}: Message payload must include at least one decision review issue completed"
+    end
+
+    decision_review_issues_completed.map { |issue| DecisionReviewIssueCompleted.new(issue) }
+  end
+end
+
+# DecisionReviewIssueCompleted represents an individual issue object from the message_payload's
+# decision_review_issues_created, decision_review_issues_Completed, decision_review_issues_removed,
+# or decision_review_issues_withdrawn arrays
+class DecisionReviewIssueCompleted
+  include MessagePayloadValidator
+
+  # Lists the attributes and corresponding data types
+  # Data types are stored in an array when the value isn't limited to one data type
+  # For example, soc_opt_in could be a boolean OR nil
+  DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES = {
+    "decision_review_issue_id" => [Integer],
+    "contention_id" => [Integer, NilClass],
+    "remand_claim_id" => [String, NilClass],
+    "remand_contention_id" => [String, NilClass],
+    "unidentified" => [TrueClass, FalseClass],
+    "prior_rating_decision_id" => [Integer, NilClass],
+    "prior_non_rating_decision_id" => [Integer, NilClass],
+    "prior_caseflow_decision_issue_id" => [Integer, NilClass],
+    "prior_decision_rating_sn" => [String, NilClass],
+    "prior_decision_text" => [String, NilClass],
+    "prior_decision_type" => [String, NilClass],
+    "prior_decision_source" => [String, NilClass],
+    "prior_decision_notification_date" => [String, NilClass],
+    "legacy_appeal_issue_id" => [Integer, NilClass],
+    "prior_decision_rating_profile_date" => [String, NilClass],
+    "soc_opt_in" => [TrueClass, FalseClass, NilClass],
+    "legacy_appeal_id" => [String, NilClass]
+  }.freeze
+  # Allows read and write access for attributes
+  DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
+
+  # When DecisionReviewIssueCompleted.new(issue_attrs) is called, this method will validate message_payload
+  # presence, attribute names and data types and assign the incoming attributes to defined keys
+  def initialize(issue = {})
+    validate(issue, self.class.name)
+    assign(issue)
+    create_decisions(issue["decision"])
+  end
+
+  private
+
+  # Lists the attributes and corresponding data types
+  def attribute_types
+    DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES
+  end
+
+  # Assigns attributes from issue_attrs to defined keys
+  def assign(issue)
+    DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES.each_key do |attr|
+      instance_variable_set("@#{attr}", issue[attr])
+    end
+  end
+
+  def create_decisions(decision)
+    return if decision.blank?
+
+    @decision = Decision.new(decision)
+  end
+end
+
+class Decision
+  include MessagePayloadValidator
+
+  DECISION_ATTRIBUTES = {
+    "contention_id" => Integer,
+    "disposition" => String,
+    "dta_error_explanation" => String,
+    "decision_source" => String,
+    "category" => String,
+    "decision_id" => Integer,
+    "decision_text" => String,
+    "award_event_id" => Integer,
+    "rating_profile_date" => String,
+    "decision_recorded_time" => String,
+    "decision_finalized_time" => String
+  }.freeze
+
+  DECISION_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }
+
+  def initialize(decision = {})
+    validate(decision, self.class.name)
+    assign(decision)
+  end
+
+  private
+
+  def attribute_types
+    DECISION_ATTRIBUTES
+  end
+
+  def assign(decision)
+    DECISION_ATTRIBUTES.each_key do |attr|
+      instance_variable_set("@#{attr}", decision[attr])
+    end
+  end
+end

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -117,7 +117,7 @@ class DecisionReviewIssueCompleted
   end
 
   def create_decisions(decision)
-    return if decision.blank?
+    return if decision.nil?
 
     @decision = Decision.new(decision)
   end
@@ -156,6 +156,12 @@ class Decision
   def assign(decision)
     DECISION_ATTRIBUTES.each_key do |attr|
       instance_variable_set("@#{attr}", decision[attr])
+    end
+  end
+
+  def validate_presence(decision, class_name)
+    if decision.blank?
+      fail ArgumentError, "#{class_name}: Message payload cannot be empty"
     end
   end
 end

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -52,7 +52,7 @@ class Transformers::DecisionReviewCompleted
 
   # Creates instances of DecisionReviewIssueCompleted, validates attributes, and assigns attributes
   # for each object in the decision_review_issues_completed array
-  # Fails out of workflow if decision_review_issues is an empty array
+  # Fails out of workflow if decision_review_issues_completed is an empty array
   def create_decision_review_issues_completed(decision_review_issues_completed)
     if decision_review_issues_completed.blank?
       fail ArgumentError,
@@ -63,9 +63,8 @@ class Transformers::DecisionReviewCompleted
   end
 end
 
-# DecisionReviewIssueCompleted represents an individual issue object from the message_payload's
-# decision_review_issues_created, decision_review_issues_Completed, decision_review_issues_removed,
-# or decision_review_issues_withdrawn arrays
+# DecisionReviewIssueCompleted represents an individual issue
+# object from the message_payload's decision_review_issues_completed
 class DecisionReviewIssueCompleted
   include MessagePayloadValidator
 
@@ -89,7 +88,8 @@ class DecisionReviewIssueCompleted
     "legacy_appeal_issue_id" => [Integer, NilClass],
     "prior_decision_rating_profile_date" => [String, NilClass],
     "soc_opt_in" => [TrueClass, FalseClass, NilClass],
-    "legacy_appeal_id" => [String, NilClass]
+    "legacy_appeal_id" => [String, NilClass],
+    "decision" => [Hash, NilClass]
   }.freeze
   # Allows read and write access for attributes
   DECISION_REVIEW_ISSUE_COMPLETED_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }

--- a/app/models/virtual/transformers/decision_review_completed.rb
+++ b/app/models/virtual/transformers/decision_review_completed.rb
@@ -133,15 +133,15 @@ class CompletedDecision
   DECISION_ATTRIBUTES = {
     "contention_id" => Integer,
     "disposition" => String,
-    "dta_error_explanation" => String,
-    "decision_source" => String,
-    "category" => String,
-    "decision_id" => Integer,
-    "decision_text" => String,
-    "award_event_id" => Integer,
-    "rating_profile_date" => String,
+    "dta_error_explanation" => [String, NilClass],
+    "decision_source" => [String, NilClass],
+    "category" => [String, NilClass],
+    "decision_id" => [Integer, NilClass],
+    "decision_text" => [String, NilClass],
+    "award_event_id" => [Integer, NilClass],
+    "rating_profile_date" => [String, NilClass],
     "decision_recorded_time" => String,
-    "decision_finalized_time" => String
+    "decision_finalized_time" => [String, NilClass]
   }.freeze
 
   DECISION_ATTRIBUTES.each_key { |attr_name| attr_accessor attr_name }

--- a/spec/models/virtual/transformers/decision_review_completed_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_completed_spec.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "shared_context/decision_review_completed_context"
+
+describe Transformers::DecisionReviewCompleted do
+  subject(:decision_review_completed) { described_class.new(event_id, message_payload) }
+
+  include_context "decision_review_completed_context"
+
+  let(:event_id) { 96 }
+
+  describe "#initialize" do
+    context "when Transformers::DecisionReviewCompleted and DecisionReviewIssue portions of payload have valid "\
+    "attributes and data types" do
+      it "initializes a Transformers::DecisionReviewCreated object" do
+        expect(subject.claim_id).to be_an_instance_of(Integer)
+        expect(subject.decision_review_type).to eq("HIGHER_LEVEL_REVIEW")
+        expect(subject.veteran_participant_id).to be_an_instance_of(String)
+        expect(subject.claimant_participant_id).to be_an_instance_of(String)
+        expect(subject.remand_created).to be_an_instance_of(NilClass)
+        expect(subject.ep_code_category).to eq("NON_RATING")
+        expect(subject.claim_lifecycle_status).to eq("CLR")
+        expect(subject.actor_username).to eq("BVADWISE101")
+        expect(subject.actor_application).to eq("PASYSACCTCREATE")
+        expect(subject.completion_time).to be_an_instance_of(String)
+        expect(subject.decision_review_issues_completed.size).to eq(2)
+      end
+
+      it "initializes DecisionReviewIssue objects for every obj in issues_array" do
+        subject.decision_review_issues_completed.each do |issue|
+          expect(issue).to be_an_instance_of(DecisionReviewIssueCompleted)
+
+          # this additional logic of checking the issues by contention_id enables us to not rely on the index each
+          # DecisionReviewIssue is stored at since the index order could change when Github Actions runs
+          case issue.contention_id
+          when 345_456_567
+            expect(issue.contention_id).to eq(345_456_567)
+            expect(issue.decision_review_issue_id).to eq(1)
+            expect(issue.remand_claim_id).to eq(1)
+            expect(issue.remand_contention_id).to eq(1)
+            expect(issue.unidentified).to eq(false)
+            expect(issue.prior_rating_decision_id).to eq(nil)
+            expect(issue.prior_non_rating_decision_id).to eq(12)
+            expect(issue.prior_caseflow_decision_issue_id).to eq(nil)
+            expect(issue.prior_decision_rating_sn).to eq(nil)
+            expect(issue.prior_decision_text).to eq("DIC: Service connection for tetnus denied")
+            expect(issue.prior_decision_type).to eq("DIC")
+            expect(issue.prior_decision_source).to eq(nil)
+            expect(issue.prior_decision_notification_date).to eq("2023-08-01")
+            expect(issue.legacy_appeal_issue_id).to eq(nil)
+            expect(issue.prior_decision_rating_profile_date).to eq(nil)
+            expect(issue.soc_opt_in).to eq(nil)
+            expect(issue.legacy_appeal_id).to eq(nil)
+          when 987_876_765
+            expect(issue.contention_id).to eq(987_876_765)
+            expect(issue.decision_review_issue_id).to eq(1)
+            expect(issue.remand_claim_id).to eq(1)
+            expect(issue.remand_contention_id).to eq(1)
+            expect(issue.unidentified).to eq(false)
+            expect(issue.prior_rating_decision_id).to eq(nil)
+            expect(issue.prior_non_rating_decision_id).to eq(12)
+            expect(issue.prior_caseflow_decision_issue_id).to eq(nil)
+            expect(issue.prior_decision_rating_sn).to eq(nil)
+            expect(issue.prior_decision_text).to eq("DIC: Service connection for tetnus denied")
+            expect(issue.prior_decision_type).to eq("DIC")
+            expect(issue.prior_decision_source).to eq(nil)
+            expect(issue.prior_decision_notification_date).to eq("2023-08-01")
+            expect(issue.legacy_appeal_issue_id).to eq(nil)
+            expect(issue.prior_decision_rating_profile_date).to eq(nil)
+            expect(issue.soc_opt_in).to eq(nil)
+            expect(issue.legacy_appeal_id).to eq(nil)
+          end
+        end
+      end
+
+      it "does not raise ArgumentError" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "when Transformers::DecisionReviewCreated portion of message_payload is invalid" do
+      context "because payload is nil" do
+        let(:nil_message_payload) { build(:decision_review_created, :nil) }
+
+        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
+          error_message = "Transformers::DecisionReviewCreated: Message payload cannot be empty or nil"
+          expect { nil_message_payload }.to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because payload is empty" do
+        let(:empty_message_payload) { build(:decision_review_created, :empty) }
+
+        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
+          error_message = "Transformers::DecisionReviewCreated: Message payload cannot be empty or nil"
+          expect { empty_message_payload }.to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "when there are unexpected attribute name(s)" do
+        let(:message_payload_with_invalid_attribute_name) { build(:decision_review_created, :invalid_attribute_name) }
+        let(:message_payload_with_multiple_invalid_names) do
+          build(:decision_review_created, :multiple_invalid_attribute_names)
+        end
+
+        context "when there is a single unexpected attribute name" do
+          it "logs the unknown attribute name" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_invalid_attribute_name
+          end
+        end
+
+        context "when there are multiple unexpected attribute names" do
+          it "logs all the unknown attribute names" do
+            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute, "\
+            "second_invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_multiple_invalid_names
+          end
+        end
+      end
+
+      context "because payload has invalid attribute data type(s)" do
+        let(:message_payload_with_invalid_data_type) { build(:decision_review_created, :invalid_data_type) }
+
+        it "raises ArgumentError with message: class_name: name must be one of the allowed types, got class." do
+          error_message = "Transformers::DecisionReviewCreated: claim_id must be one of the allowed types "\
+          "- [Integer], got String"
+          expect { message_payload_with_invalid_data_type }.to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because decision_review_issues_created is an empty array" do
+        let(:message_payload_without_decision_review_issues_created) do
+          build(:decision_review_created, :without_decision_review_issues_created)
+        end
+
+        it "raises ArgumentError with message: Transformers::DecisionReviewCreated: Message payload must include at "\
+        "least one decision review issue" do
+          error_message = "Transformers::DecisionReviewCreated: Message payload must include at least one decision "\
+          "review issue created"
+          expect { message_payload_without_decision_review_issues_created }.to raise_error(ArgumentError, error_message)
+        end
+      end
+    end
+
+    context "when DecisionReviewIssue portion of message_payload is invalid" do
+      context "because payload is nil" do
+        let(:message_payload_with_nil_issue) do
+          build(:decision_review_created, :with_nil_decision_review_issue_created)
+        end
+
+        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
+          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
+          expect { message_payload_with_nil_issue }.to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because payload is empty" do
+        let(:message_payload_with_empty_issue) do
+          build(:decision_review_created, :with_empty_decision_review_issue_created)
+        end
+
+        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
+          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
+          expect { message_payload_with_empty_issue }.to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because payload has invalid attribute name(s)" do
+        let(:message_payload_with_invalid_issue_attr_name) do
+          build(:decision_review_created, :with_invalid_decision_review_issue_created_attribute_name)
+        end
+        let(:message_payload_with_multiple_invalid_issue_attr_names) do
+          build(:decision_review_created, :with_multiple_invalid_decision_review_issue_created_attribute_names)
+        end
+
+        context "when there is a single unexpected attribute name" do
+          it "logs the unknown attribute name" do
+            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_invalid_issue_attr_name
+          end
+        end
+
+        context "when there are multiple unexpected attribute names" do
+          it "logs all the unknown attribute names" do
+            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute, "\
+            "second_invalid_attribute"
+            expect(Rails.logger).to receive(:info).with(message)
+            message_payload_with_multiple_invalid_issue_attr_names
+          end
+        end
+      end
+
+      context "because payload has invalid attribute data type(s)" do
+        let(:message_payload_with_invalid_issue_data_type) do
+          build(:decision_review_created, :with_invalid_decision_review_issue_created_data_type)
+        end
+
+        it "raises ArgumentError with message: class_name: name must be one of the allowed types -, got class." do
+          error_message = "DecisionReviewIssueCreated: decision_review_issue_id must be one of the allowed types -" \
+           " [Integer], got String"
+          expect { message_payload_with_invalid_issue_data_type }.to raise_error(ArgumentError, error_message)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/virtual/transformers/decision_review_completed_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_completed_spec.rb
@@ -10,65 +10,99 @@ describe Transformers::DecisionReviewCompleted do
   let(:event_id) { 96 }
 
   describe "#initialize" do
-    context "when Transformers::DecisionReviewCompleted and DecisionReviewIssue portions of payload have valid "\
-    "attributes and data types" do
-      it "initializes a Transformers::DecisionReviewCreated object" do
-        expect(subject.claim_id).to be_an_instance_of(Integer)
-        expect(subject.decision_review_type).to eq("HIGHER_LEVEL_REVIEW")
-        expect(subject.veteran_participant_id).to be_an_instance_of(String)
-        expect(subject.claimant_participant_id).to be_an_instance_of(String)
-        expect(subject.remand_created).to be_an_instance_of(NilClass)
-        expect(subject.ep_code_category).to eq("NON_RATING")
-        expect(subject.claim_lifecycle_status).to eq("CLR")
-        expect(subject.actor_username).to eq("BVADWISE101")
-        expect(subject.actor_application).to eq("PASYSACCTCREATE")
-        expect(subject.completion_time).to be_an_instance_of(String)
+    context "when Transformers::DecisionReviewCompleted, DecisionReviewIssueCompleted, and Decision" \
+    " portions of payload have valid attributes and data types" do
+      it "initializes a Transformers::DecisionReviewCompleted object" do
+        expect(subject.claim_id).to eq(message_payload["claim_id"])
+        expect(subject.decision_review_type).to eq(message_payload["decision_review_type"])
+        expect(subject.veteran_participant_id).to eq(message_payload["veteran_participant_id"])
+        expect(subject.claimant_participant_id).to eq(message_payload["claimant_participant_id"])
+        expect(subject.remand_created).to eq(message_payload["remand_created"])
+        expect(subject.ep_code_category).to eq(message_payload["ep_code_category"])
+        expect(subject.claim_lifecycle_status).to eq(message_payload["claim_lifecycle_status"])
+        expect(subject.actor_username).to eq(message_payload["actor_username"])
+        expect(subject.actor_application).to eq(message_payload["actor_application"])
+        expect(subject.completion_time).to eq(message_payload["completion_time"])
         expect(subject.decision_review_issues_completed.size).to eq(2)
       end
 
-      it "initializes DecisionReviewIssue objects for every obj in issues_array" do
+      it "initializes DecisionReviewIssueCompleted objects for every obj in decision_review_issues_completed array" do
         subject.decision_review_issues_completed.each do |issue|
           expect(issue).to be_an_instance_of(DecisionReviewIssueCompleted)
 
           # this additional logic of checking the issues by contention_id enables us to not rely on the index each
-          # DecisionReviewIssue is stored at since the index order could change when Github Actions runs
+          # DecisionReviewIssueCompleted is stored at since the index order could change when Github Actions runs
           case issue.contention_id
           when 345_456_567
-            expect(issue.contention_id).to eq(345_456_567)
-            expect(issue.decision_review_issue_id).to eq(1)
-            expect(issue.remand_claim_id).to eq(1)
-            expect(issue.remand_contention_id).to eq(1)
-            expect(issue.unidentified).to eq(false)
-            expect(issue.prior_rating_decision_id).to eq(nil)
-            expect(issue.prior_non_rating_decision_id).to eq(12)
-            expect(issue.prior_caseflow_decision_issue_id).to eq(nil)
-            expect(issue.prior_decision_rating_sn).to eq(nil)
-            expect(issue.prior_decision_text).to eq("DIC: Service connection for tetnus denied")
-            expect(issue.prior_decision_type).to eq("DIC")
-            expect(issue.prior_decision_source).to eq(nil)
-            expect(issue.prior_decision_notification_date).to eq("2023-08-01")
-            expect(issue.legacy_appeal_issue_id).to eq(nil)
-            expect(issue.prior_decision_rating_profile_date).to eq(nil)
-            expect(issue.soc_opt_in).to eq(nil)
-            expect(issue.legacy_appeal_id).to eq(nil)
+            expect(issue.contention_id).to eq(completed_decision_review_issue["contention_id"])
+            expect(issue.decision_review_issue_id).to eq(completed_decision_review_issue["decision_review_issue_id"])
+            expect(issue.remand_claim_id).to eq(completed_decision_review_issue["remand_claim_id"])
+            expect(issue.remand_contention_id).to eq(completed_decision_review_issue["remand_contention_id"])
+            expect(issue.unidentified).to eq(completed_decision_review_issue["unidentified"])
+            expect(issue.prior_rating_decision_id).to eq(completed_decision_review_issue["prior_rating_decision_id"])
+            expect(issue.prior_non_rating_decision_id)
+              .to eq(completed_decision_review_issue["prior_non_rating_decision_id"])
+            expect(issue.prior_caseflow_decision_issue_id)
+              .to eq(completed_decision_review_issue["prior_caseflow_decision_issue_id"])
+            expect(issue.prior_decision_rating_sn).to eq(completed_decision_review_issue["prior_decision_rating_sn"])
+            expect(issue.prior_decision_text).to eq(completed_decision_review_issue["prior_decision_text"])
+            expect(issue.prior_decision_type).to eq(completed_decision_review_issue["prior_decision_type"])
+            expect(issue.prior_decision_source).to eq(completed_decision_review_issue["prior_decision_source"])
+            expect(issue.prior_decision_notification_date)
+              .to eq(completed_decision_review_issue["prior_decision_notification_date"])
+            expect(issue.legacy_appeal_issue_id).to eq(completed_decision_review_issue["legacy_appeal_issue_id"])
+            expect(issue.prior_decision_rating_profile_date)
+              .to eq(completed_decision_review_issue["prior_decision_rating_profile_date"])
+            expect(issue.soc_opt_in).to eq(completed_decision_review_issue["soc_opt_in"])
+            expect(issue.legacy_appeal_id).to eq(completed_decision_review_issue["legacy_appeal_id"])
           when 987_876_765
-            expect(issue.contention_id).to eq(987_876_765)
-            expect(issue.decision_review_issue_id).to eq(1)
-            expect(issue.remand_claim_id).to eq(1)
-            expect(issue.remand_contention_id).to eq(1)
-            expect(issue.unidentified).to eq(false)
-            expect(issue.prior_rating_decision_id).to eq(nil)
-            expect(issue.prior_non_rating_decision_id).to eq(12)
-            expect(issue.prior_caseflow_decision_issue_id).to eq(nil)
-            expect(issue.prior_decision_rating_sn).to eq(nil)
-            expect(issue.prior_decision_text).to eq("DIC: Service connection for tetnus denied")
-            expect(issue.prior_decision_type).to eq("DIC")
-            expect(issue.prior_decision_source).to eq(nil)
-            expect(issue.prior_decision_notification_date).to eq("2023-08-01")
-            expect(issue.legacy_appeal_issue_id).to eq(nil)
-            expect(issue.prior_decision_rating_profile_date).to eq(nil)
-            expect(issue.soc_opt_in).to eq(nil)
-            expect(issue.legacy_appeal_id).to eq(nil)
+            expect(issue.contention_id).to eq(canceled_decision_review_issue["contention_id"])
+            expect(issue.decision_review_issue_id).to eq(canceled_decision_review_issue["decision_review_issue_id"])
+            expect(issue.remand_claim_id).to eq(canceled_decision_review_issue["remand_claim_id"])
+            expect(issue.remand_contention_id).to eq(canceled_decision_review_issue["remand_contention_id"])
+            expect(issue.unidentified).to eq(canceled_decision_review_issue["unidentified"])
+            expect(issue.prior_rating_decision_id).to eq(canceled_decision_review_issue["prior_rating_decision_id"])
+            expect(issue.prior_non_rating_decision_id)
+              .to eq(canceled_decision_review_issue["prior_non_rating_decision_id"])
+            expect(issue.prior_caseflow_decision_issue_id)
+              .to eq(canceled_decision_review_issue["prior_caseflow_decision_issue_id"])
+            expect(issue.prior_decision_rating_sn).to eq(canceled_decision_review_issue["prior_decision_rating_sn"])
+            expect(issue.prior_decision_text).to eq(canceled_decision_review_issue["prior_decision_text"])
+            expect(issue.prior_decision_type).to eq(canceled_decision_review_issue["prior_decision_type"])
+            expect(issue.prior_decision_source).to eq(canceled_decision_review_issue["prior_decision_source"])
+            expect(issue.prior_decision_notification_date)
+              .to eq(canceled_decision_review_issue["prior_decision_notification_date"])
+            expect(issue.legacy_appeal_issue_id).to eq(canceled_decision_review_issue["legacy_appeal_issue_id"])
+            expect(issue.prior_decision_rating_profile_date)
+              .to eq(canceled_decision_review_issue["prior_decision_rating_profile_date"])
+            expect(issue.soc_opt_in).to eq(canceled_decision_review_issue["soc_opt_in"])
+            expect(issue.legacy_appeal_id).to eq(canceled_decision_review_issue["legacy_appeal_id"])
+          end
+        end
+      end
+
+      it "initializes a Decision object for every DecisionReviewIssueCompleted"\
+      " with a non-nil decision field" do
+        subject.decision_review_issues_completed.each do |issue|
+          decision = issue.decision
+
+          case issue.contention_id
+          when 345_456_567
+            expect(decision).to be_an_instance_of(Decision)
+            expect(decision.contention_id).to eq(completed_decision["contention_id"])
+            expect(decision.disposition).to eq(completed_decision["disposition"])
+            expect(decision.dta_error_explanation).to eq(completed_decision["dta_error_explanation"])
+            expect(decision.decision_source).to eq(completed_decision["decision_source"])
+            expect(decision.category).to eq(completed_decision["category"])
+            expect(decision.decision_id).to eq(completed_decision["decision_id"])
+            expect(decision.decision_text).to eq(completed_decision["decision_text"])
+            expect(decision.award_event_id).to eq(completed_decision["award_event_id"])
+            expect(decision.rating_profile_date).to eq(completed_decision["rating_profile_date"])
+            expect(decision.decision_recorded_time).to eq(completed_decision["decision_recorded_time"])
+            expect(decision.decision_finalized_time).to eq(completed_decision["decision_finalized_time"])
+          when 987_876_765
+            expect(decision).not_to be_an_instance_of(Decision)
+            expect(decision).to be_nil
           end
         end
       end
@@ -78,131 +112,164 @@ describe Transformers::DecisionReviewCompleted do
       end
     end
 
-    context "when Transformers::DecisionReviewCreated portion of message_payload is invalid" do
+    context "when Transformers::DecisionReviewCompleted portion of message_payload is invalid" do
       context "because payload is nil" do
-        let(:nil_message_payload) { build(:decision_review_created, :nil) }
+        let(:nil_message_payload) { described_class.new(nil, nil) }
 
-        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "Transformers::DecisionReviewCreated: Message payload cannot be empty or nil"
+        it "raises ArgumentError with message" do
+          error_message = /Transformers::DecisionReviewCompleted: Message payload cannot be empty or nil/
           expect { nil_message_payload }.to raise_error(ArgumentError, error_message)
         end
       end
 
       context "because payload is empty" do
-        let(:empty_message_payload) { build(:decision_review_created, :empty) }
+        let(:empty_message_payload) { described_class.new(nil, {}) }
 
-        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "Transformers::DecisionReviewCreated: Message payload cannot be empty or nil"
+        it "raises ArgumentError with message" do
+          error_message = /Transformers::DecisionReviewCompleted: Message payload cannot be empty or nil/
           expect { empty_message_payload }.to raise_error(ArgumentError, error_message)
         end
       end
 
-      context "when there are unexpected attribute name(s)" do
-        let(:message_payload_with_invalid_attribute_name) { build(:decision_review_created, :invalid_attribute_name) }
-        let(:message_payload_with_multiple_invalid_names) do
-          build(:decision_review_created, :multiple_invalid_attribute_names)
-        end
-
-        context "when there is a single unexpected attribute name" do
-          it "logs the unknown attribute name" do
-            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute"
-            expect(Rails.logger).to receive(:info).with(message)
-            message_payload_with_invalid_attribute_name
-          end
-        end
-
-        context "when there are multiple unexpected attribute names" do
-          it "logs all the unknown attribute names" do
-            message = "Transformers::DecisionReviewCreated: Unknown attributes - invalid_attribute, "\
-            "second_invalid_attribute"
-            expect(Rails.logger).to receive(:info).with(message)
-            message_payload_with_multiple_invalid_names
-          end
-        end
-      end
-
       context "because payload has invalid attribute data type(s)" do
-        let(:message_payload_with_invalid_data_type) { build(:decision_review_created, :invalid_data_type) }
+        let(:message_payload_with_invalid_data_type) do
+          message_payload.merge(
+            "claim_id" => "87213"
+          )
+        end
 
-        it "raises ArgumentError with message: class_name: name must be one of the allowed types, got class." do
-          error_message = "Transformers::DecisionReviewCreated: claim_id must be one of the allowed types "\
+        it "raises ArgumentError with message" do
+          error_message = "Transformers::DecisionReviewCompleted: claim_id must be one of the allowed types "\
           "- [Integer], got String"
-          expect { message_payload_with_invalid_data_type }.to raise_error(ArgumentError, error_message)
+          expect { described_class.new(event_id, message_payload_with_invalid_data_type) }
+            .to raise_error(ArgumentError, error_message)
         end
       end
 
-      context "because decision_review_issues_created is an empty array" do
-        let(:message_payload_without_decision_review_issues_created) do
-          build(:decision_review_created, :without_decision_review_issues_created)
+      context "because payload has unexpected attribute name(s)" do
+        let(:message_payload_with_multiple_invalid_attribute_names) do
+          message_payload.merge(
+            "invalid_attr" => "key",
+            "second_invalid_attr" => 123
+          )
         end
-
-        it "raises ArgumentError with message: Transformers::DecisionReviewCreated: Message payload must include at "\
-        "least one decision review issue" do
-          error_message = "Transformers::DecisionReviewCreated: Message payload must include at least one decision "\
-          "review issue created"
-          expect { message_payload_without_decision_review_issues_created }.to raise_error(ArgumentError, error_message)
+        it "logs all the unknown attribute names" do
+          message = "Transformers::DecisionReviewCompleted: Unknown attributes - invalid_attr, "\
+          "second_invalid_attr"
+          expect(Rails.logger).to receive(:info).with(message)
+          described_class.new(event_id, message_payload_with_multiple_invalid_attribute_names)
         end
       end
     end
 
-    context "when DecisionReviewIssue portion of message_payload is invalid" do
-      context "because payload is nil" do
-        let(:message_payload_with_nil_issue) do
-          build(:decision_review_created, :with_nil_decision_review_issue_created)
+    context "when DecisionReviewIssueCompleted portion of message_payload is invalid" do
+      context "because decision_review_issues_completed is an empty array" do
+        let(:message_payload_with_empty_decision_review_issues_completed) do
+          message_payload.merge(
+            "decision_review_issues_completed" => []
+          )
         end
 
-        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
-          expect { message_payload_with_nil_issue }.to raise_error(ArgumentError, error_message)
+        it "raises ArgumentError with message" do
+          error_message = "Transformers::DecisionReviewCompleted: Message payload must include at least one decision "\
+          "review issue completed"
+          expect { described_class.new(event_id, message_payload_with_empty_decision_review_issues_completed) }
+            .to raise_error(ArgumentError, error_message)
         end
       end
 
-      context "because payload is empty" do
+      context "because decision_review_issues_completed hash is empty" do
         let(:message_payload_with_empty_issue) do
-          build(:decision_review_created, :with_empty_decision_review_issue_created)
+          message_payload.merge(
+            "decision_review_issues_completed" => [{}]
+          )
         end
 
-        it "raises ArgumentError with message: class_name: Message payload cannot be empty or nil" do
-          error_message = "DecisionReviewIssueCreated: Message payload cannot be empty or nil"
-          expect { message_payload_with_empty_issue }.to raise_error(ArgumentError, error_message)
+        it "raises ArgumentError with message" do
+          error_message = /DecisionReviewIssueCompleted: Message payload cannot be empty or nil/
+          expect { described_class.new(event_id, message_payload_with_empty_issue) }
+            .to raise_error(ArgumentError, error_message)
         end
       end
 
-      context "because payload has invalid attribute name(s)" do
-        let(:message_payload_with_invalid_issue_attr_name) do
-          build(:decision_review_created, :with_invalid_decision_review_issue_created_attribute_name)
+      context "because decision_review_issues_completed has invalid data type(s)" do
+        let(:decision_review_issue_completed_with_invalid_data_type) do
+          completed_decision_review_issue.merge(
+            "contention_id" => "string data type"
+          )
         end
-        let(:message_payload_with_multiple_invalid_issue_attr_names) do
-          build(:decision_review_created, :with_multiple_invalid_decision_review_issue_created_attribute_names)
-        end
-
-        context "when there is a single unexpected attribute name" do
-          it "logs the unknown attribute name" do
-            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute"
-            expect(Rails.logger).to receive(:info).with(message)
-            message_payload_with_invalid_issue_attr_name
-          end
-        end
-
-        context "when there are multiple unexpected attribute names" do
-          it "logs all the unknown attribute names" do
-            message = "DecisionReviewIssueCreated: Unknown attributes - invalid_attribute, "\
-            "second_invalid_attribute"
-            expect(Rails.logger).to receive(:info).with(message)
-            message_payload_with_multiple_invalid_issue_attr_names
-          end
-        end
-      end
-
-      context "because payload has invalid attribute data type(s)" do
         let(:message_payload_with_invalid_issue_data_type) do
-          build(:decision_review_created, :with_invalid_decision_review_issue_created_data_type)
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_invalid_data_type]
+          )
         end
 
-        it "raises ArgumentError with message: class_name: name must be one of the allowed types -, got class." do
-          error_message = "DecisionReviewIssueCreated: decision_review_issue_id must be one of the allowed types -" \
-           " [Integer], got String"
-          expect { message_payload_with_invalid_issue_data_type }.to raise_error(ArgumentError, error_message)
+        it "raises ArgumentError with message" do
+          error_message = "DecisionReviewIssueCompleted: contention_id must be one of the allowed types"\
+          " - [Integer, NilClass], got String"
+          expect { described_class.new(event_id, message_payload_with_invalid_issue_data_type) }
+            .to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because decision_review_issues_completed has invalid attribute name(s)" do
+        let(:decision_review_issue_completed_with_invalid_attr_names) do
+          completed_decision_review_issue.merge(
+            "invalid_attr" => "string",
+            "second_invalid_attr" => 1234
+          )
+        end
+        let(:message_payload_with_invalid_issue_attr_names) do
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_invalid_attr_names]
+          )
+        end
+
+        it "logs all the unknown attribute names" do
+          message = "DecisionReviewIssueCompleted: Unknown attributes - invalid_attr, "\
+          "second_invalid_attr"
+          expect(Rails.logger).to receive(:info).with(message)
+          described_class.new(event_id, message_payload_with_invalid_issue_attr_names)
+        end
+      end
+    end
+
+    context "when Decision portion of message_payload is invalid" do
+      context "because decision has invalid data type(s)" do
+        let(:decision_review_issue_completed_with_invalid_attr_types) do
+          completed_decision_review_issue.merge(
+            "decision" => decision_with_invalid_attr_types
+          )
+        end
+        let(:message_payload_with_invalid_attr_types) do
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_invalid_attr_types]
+          )
+        end
+
+        it "raises ArgumentError with message" do
+          error_message = "Decision: contention_id must be one of the allowed types - [Integer], got String"
+          expect { described_class.new(event_id, message_payload_with_invalid_attr_types) }
+            .to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because decision has invalid attribute name(s)" do
+        let(:decision_review_issue_completed_with_invalid_attr_names) do
+          completed_decision_review_issue.merge(
+            "decision" => decision_with_invalid_attr_names
+          )
+        end
+        let(:message_payload_with_invalid_attr_names) do
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_invalid_attr_names]
+          )
+        end
+
+        it "logs all the unknown attribute names" do
+          message = /Decision: Unknown attributes - invalid_attr, second_invalid_attr/
+          expect(Rails.logger).to receive(:info).with(message)
+          described_class.new(event_id, message_payload_with_invalid_attr_names)
         end
       end
     end

--- a/spec/models/virtual/transformers/decision_review_completed_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_completed_spec.rb
@@ -133,6 +133,18 @@ describe Transformers::DecisionReviewCompleted do
         end
       end
 
+      context "because required attribute is missing" do
+        let(:message_payload_with_missing_attribute) do
+          message_payload.except("claim_id")
+        end
+
+        it "raises ArgumentError with message" do
+          error_message = "#{drc_class}: claim_id must be one of the allowed types - [Integer], got NilClass"
+          expect { described_class.new(event_id, message_payload_with_missing_attribute) }
+            .to raise_error(ArgumentError, error_message)
+        end
+      end
+
       context "because payload has invalid attribute data type(s)" do
         let(:message_payload_with_invalid_data_type) do
           message_payload.merge(
@@ -154,7 +166,7 @@ describe Transformers::DecisionReviewCompleted do
             "second_invalid_attr" => 123
           )
         end
-        it "logs all the unknown attribute names" do
+        it "logs all unknown attribute names" do
           message = "#{drc_class}: Unknown attributes - invalid_attr, second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
           described_class.new(event_id, message_payload_with_multiple_invalid_attribute_names)
@@ -187,6 +199,24 @@ describe Transformers::DecisionReviewCompleted do
         it "raises ArgumentError with message" do
           error_message = "DecisionReviewIssueCompleted: Message payload cannot be empty or nil"
           expect { described_class.new(event_id, message_payload_with_empty_issue) }
+            .to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because required attribute is missing" do
+        let(:decision_review_issue_completed_with_missing_attr) do
+          completed_decision_review_issue.except("decision_review_issue_id")
+        end
+        let(:message_payload_with_missing_attribute) do
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_missing_attr]
+          )
+        end
+
+        it "raises ArgumentError with message" do
+          error_message = "DecisionReviewIssueCompleted: decision_review_issue_id must be"\
+          " one of the allowed types - [Integer], got NilClass"
+          expect { described_class.new(event_id, message_payload_with_missing_attribute) }
             .to raise_error(ArgumentError, error_message)
         end
       end
@@ -224,7 +254,7 @@ describe Transformers::DecisionReviewCompleted do
           )
         end
 
-        it "logs all the unknown attribute names" do
+        it "logs all unknown attribute names" do
           message = "DecisionReviewIssueCompleted: Unknown attributes - invalid_attr, "\
           "second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
@@ -249,6 +279,25 @@ describe Transformers::DecisionReviewCompleted do
         it "raises ArgumentError with message" do
           error_message = "CompletedDecision: Message payload cannot be empty"
           expect { described_class.new(event_id, message_payload_with_nil_decision) }
+            .to raise_error(ArgumentError, error_message)
+        end
+      end
+
+      context "because required attribute is missing" do
+        let(:decision_review_issue_completed_with_missing_attr) do
+          completed_decision_review_issue.merge(
+            "decision" => decision_with_missing_attribute
+          )
+        end
+        let(:message_payload_with_missing_attribute) do
+          message_payload.merge(
+            "decision_review_issues_completed" => [decision_review_issue_completed_with_missing_attr]
+          )
+        end
+
+        it "raises ArgumentError with message" do
+          error_message = "CompletedDecision: disposition must be one of the allowed types - [String], got NilClass"
+          expect { described_class.new(event_id, message_payload_with_missing_attribute) }
             .to raise_error(ArgumentError, error_message)
         end
       end
@@ -284,7 +333,7 @@ describe Transformers::DecisionReviewCompleted do
           )
         end
 
-        it "logs all the unknown attribute names" do
+        it "logs all unknown attribute names" do
           message = "CompletedDecision: Unknown attributes - invalid_attr, second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
           described_class.new(event_id, message_payload_with_invalid_attr_names)

--- a/spec/models/virtual/transformers/decision_review_completed_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_completed_spec.rb
@@ -8,7 +8,9 @@ describe Transformers::DecisionReviewCompleted do
   include_context "decision_review_completed_context"
 
   let(:event_id) { 96 }
-  let(:drc_class) { decision_review_completed.class }
+  let(:drc_class) { "Transformers::DecisionReviewCompleted" }
+  let(:decision_review_issue_completed_class) { "DecisionReviewIssueCompleted" }
+  let(:decision_class) { "CompletedDecision" }
 
   describe "#initialize" do
     context "when Transformers::DecisionReviewCompleted, DecisionReviewIssueCompleted, and CompletedDecision" \
@@ -197,7 +199,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "DecisionReviewIssueCompleted: Message payload cannot be empty or nil"
+          error_message = "#{decision_review_issue_completed_class}: Message payload cannot be empty or nil"
           expect { described_class.new(event_id, message_payload_with_empty_issue) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -214,7 +216,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "DecisionReviewIssueCompleted: decision_review_issue_id must be"\
+          error_message = "#{decision_review_issue_completed_class}: decision_review_issue_id must be"\
           " one of the allowed types - [Integer], got NilClass"
           expect { described_class.new(event_id, message_payload_with_missing_attribute) }
             .to raise_error(ArgumentError, error_message)
@@ -234,7 +236,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "DecisionReviewIssueCompleted: contention_id must be one of the allowed types"\
+          error_message = "#{decision_review_issue_completed_class}: contention_id must be one of the allowed types"\
           " - [Integer, NilClass], got String"
           expect { described_class.new(event_id, message_payload_with_invalid_issue_data_type) }
             .to raise_error(ArgumentError, error_message)
@@ -255,7 +257,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "logs all unknown attribute names" do
-          message = "DecisionReviewIssueCompleted: Unknown attributes - invalid_attr, "\
+          message = "#{decision_review_issue_completed_class}: Unknown attributes - invalid_attr, "\
           "second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
           described_class.new(event_id, message_payload_with_invalid_issue_attr_names)
@@ -277,7 +279,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "CompletedDecision: Message payload cannot be empty"
+          error_message = "#{decision_class}: Message payload cannot be empty"
           expect { described_class.new(event_id, message_payload_with_nil_decision) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -296,7 +298,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "CompletedDecision: disposition must be one of the allowed types - [String], got NilClass"
+          error_message = "#{decision_class}: disposition must be one of the allowed types - [String], got NilClass"
           expect { described_class.new(event_id, message_payload_with_missing_attribute) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -315,7 +317,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "CompletedDecision: contention_id must be one of the allowed types - [Integer], got String"
+          error_message = "#{decision_class}: contention_id must be one of the allowed types - [Integer], got String"
           expect { described_class.new(event_id, message_payload_with_invalid_attr_types) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -334,7 +336,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "logs all unknown attribute names" do
-          message = "CompletedDecision: Unknown attributes - invalid_attr, second_invalid_attr"
+          message = "#{decision_class}: Unknown attributes - invalid_attr, second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
           described_class.new(event_id, message_payload_with_invalid_attr_names)
         end

--- a/spec/models/virtual/transformers/decision_review_completed_spec.rb
+++ b/spec/models/virtual/transformers/decision_review_completed_spec.rb
@@ -11,7 +11,7 @@ describe Transformers::DecisionReviewCompleted do
   let(:drc_class) { decision_review_completed.class }
 
   describe "#initialize" do
-    context "when Transformers::DecisionReviewCompleted, DecisionReviewIssueCompleted, and Decision" \
+    context "when Transformers::DecisionReviewCompleted, DecisionReviewIssueCompleted, and CompletedDecision" \
     " portions of payload have valid attributes and data types" do
       it "initializes a Transformers::DecisionReviewCompleted object" do
         expect(subject.claim_id).to eq(message_payload["claim_id"])
@@ -83,14 +83,14 @@ describe Transformers::DecisionReviewCompleted do
         end
       end
 
-      it "initializes a Decision object for every DecisionReviewIssueCompleted"\
+      it "initializes a CompletedDecision object for every DecisionReviewIssueCompleted"\
       " with a non-nil decision field" do
         subject.decision_review_issues_completed.each do |issue|
           decision = issue.decision
 
           case issue.contention_id
           when 345_456_567
-            expect(decision).to be_an_instance_of(Decision)
+            expect(decision).to be_an_instance_of(CompletedDecision)
             expect(decision.contention_id).to eq(completed_decision["contention_id"])
             expect(decision.disposition).to eq(completed_decision["disposition"])
             expect(decision.dta_error_explanation).to eq(completed_decision["dta_error_explanation"])
@@ -103,7 +103,7 @@ describe Transformers::DecisionReviewCompleted do
             expect(decision.decision_recorded_time).to eq(completed_decision["decision_recorded_time"])
             expect(decision.decision_finalized_time).to eq(completed_decision["decision_finalized_time"])
           when 987_876_765
-            expect(decision).not_to be_an_instance_of(Decision)
+            expect(decision).not_to be_an_instance_of(CompletedDecision)
             expect(decision).to be_nil
           end
         end
@@ -233,7 +233,7 @@ describe Transformers::DecisionReviewCompleted do
       end
     end
 
-    context "when Decision portion of message_payload is invalid" do
+    context "when CompletedDecision portion of message_payload is invalid" do
       context "because decision is an empty hash" do
         let(:decision_review_issue_completed_with_nil_decision) do
           completed_decision_review_issue.merge(
@@ -247,7 +247,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "Decision: Message payload cannot be empty"
+          error_message = "CompletedDecision: Message payload cannot be empty"
           expect { described_class.new(event_id, message_payload_with_nil_decision) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -266,7 +266,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "raises ArgumentError with message" do
-          error_message = "Decision: contention_id must be one of the allowed types - [Integer], got String"
+          error_message = "CompletedDecision: contention_id must be one of the allowed types - [Integer], got String"
           expect { described_class.new(event_id, message_payload_with_invalid_attr_types) }
             .to raise_error(ArgumentError, error_message)
         end
@@ -285,7 +285,7 @@ describe Transformers::DecisionReviewCompleted do
         end
 
         it "logs all the unknown attribute names" do
-          message = "Decision: Unknown attributes - invalid_attr, second_invalid_attr"
+          message = "CompletedDecision: Unknown attributes - invalid_attr, second_invalid_attr"
           expect(Rails.logger).to receive(:info).with(message)
           described_class.new(event_id, message_payload_with_invalid_attr_names)
         end

--- a/spec/shared_context/decision_review_completed_context.rb
+++ b/spec/shared_context/decision_review_completed_context.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+shared_context "decision_review_completed_context" do
+  let(:message_payload) do
+    {
+      "claim_id" => 1_234_567,
+      "decision_review_type" => "HIGHER_LEVEL_REVIEW",
+      "veteran_participant_id" => "123456789",
+      "claimant_participant_id" => "01010101",
+      "remand_created" => nil,
+      "ep_code_category" => "NON_RATING",
+      "claim_lifecycle_status" => "CLR",
+      "actor_username" => "BVADWISE101",
+      "actor_application" => "PASYSACCTCREATE",
+      "completion_time" => "String",
+      "decision_review_issues_completed" => decision_review_issues_completed
+    }
+  end
+
+  let(:decision_review_issues_completed) do
+    [
+      completed_decision_review_issue,
+      canceled_decision_review_issue
+    ]
+  end
+
+  let(:completed_decision_review_issue) do
+    base_decision_review_issue.merge(
+      "contention_id" => 345_456_567,
+      "decision_review_issue_id" => 1,
+      "decision" => completed_decision
+    )
+  end
+
+  let(:canceled_decision_review_issue) do
+    base_decision_review_issue.merge(
+      "contention_id" => 987_876_765,
+      "decision_review_issue_id" => 9,
+      "decision" => canceled_decision
+    )
+  end
+
+  let(:base_decision_review_issue) do
+    {
+      "decision_review_issue_id" => 1,
+      "contention_id" => 2,
+      "remand_claim_id" => "8675309",
+      "remand_contention_id" => "9035768",
+      "unidentified" => true,
+      "prior_rating_decision_id" => nil,
+      "prior_non_rating_decision_id" => nil,
+      "prior_caseflow_decision_issue_id" => nil,
+      "prior_decision_rating_sn" => nil,
+      "prior_decision_text" => nil,
+      "prior_decision_type" => "Unknown",
+      "prior_decision_source" => nil,
+      "prior_decision_notification_date" => nil,
+      "legacy_appeal_issue_id" => nil,
+      "prior_decision_rating_profile_date" => nil,
+      "soc_opt_in" => nil,
+      "legacy_appeal_id" => nil
+    }
+  end
+
+  let(:completed_decision) do
+    base_decision.merge(
+      "contention_id" => 8_342_759,
+      "disposition" => "Approved"
+    )
+  end
+
+  let(:canceled_decision) do
+    base_decision.merge(
+      "contention_id" => 4_567_890,
+      "disposition" => "Approved"
+    )
+  end
+
+  let(:base_decision) do
+    {
+      "contention_id" => 1_234_567,
+      "disposition" => "Approved",
+      "dta_error_explanation" => "None",
+      "decision_source" => "Source",
+      "category" => "Category",
+      "decision_id" => 2,
+      "decision_text" => "Decision text",
+      "award_event_id" => 3,
+      "rating_profile_date" => "2023-07-22",
+      "decision_recorded_time" => "",
+      "decision_finalized_time" => ""
+    }
+  end
+end

--- a/spec/shared_context/decision_review_completed_context.rb
+++ b/spec/shared_context/decision_review_completed_context.rb
@@ -40,6 +40,26 @@ shared_context "decision_review_completed_context" do
     )
   end
 
+  let(:completed_decision) do
+    base_decision.merge(
+      "contention_id" => 8_342_759,
+      "disposition" => "Approved"
+    )
+  end
+
+  let(:decision_with_invalid_attr_types) do
+    base_decision.merge(
+      "contention_id" => "87654"
+    )
+  end
+
+  let(:decision_with_invalid_attr_names) do
+    base_decision.merge(
+      "invalid_attr" => "key",
+      "second_invalid_attr" => 44_494
+    )
+  end
+
   let(:base_decision_review_issue) do
     {
       "decision_review_issue_id" => 1,
@@ -60,26 +80,6 @@ shared_context "decision_review_completed_context" do
       "soc_opt_in" => nil,
       "legacy_appeal_id" => nil
     }
-  end
-
-  let(:completed_decision) do
-    base_decision.merge(
-      "contention_id" => 8_342_759,
-      "disposition" => "Approved"
-    )
-  end
-
-  let(:decision_with_invalid_attr_types) do
-    base_decision.merge(
-      "contention_id" => "87654"
-    )
-  end
-
-  let(:decision_with_invalid_attr_names) do
-    base_decision.merge(
-      "invalid_attr" => "key",
-      "second_invalid_attr" => 44_494
-    )
   end
 
   let(:base_decision) do

--- a/spec/shared_context/decision_review_completed_context.rb
+++ b/spec/shared_context/decision_review_completed_context.rb
@@ -60,6 +60,10 @@ shared_context "decision_review_completed_context" do
     )
   end
 
+  let(:decision_with_missing_attribute) do
+    base_decision.except("disposition")
+  end
+
   let(:base_decision_review_issue) do
     {
       "decision_review_issue_id" => 1,

--- a/spec/shared_context/decision_review_completed_context.rb
+++ b/spec/shared_context/decision_review_completed_context.rb
@@ -36,7 +36,7 @@ shared_context "decision_review_completed_context" do
     base_decision_review_issue.merge(
       "contention_id" => 987_876_765,
       "decision_review_issue_id" => 9,
-      "decision" => canceled_decision
+      "decision" => nil
     )
   end
 
@@ -69,10 +69,16 @@ shared_context "decision_review_completed_context" do
     )
   end
 
-  let(:canceled_decision) do
+  let(:decision_with_invalid_attr_types) do
     base_decision.merge(
-      "contention_id" => 4_567_890,
-      "disposition" => "Approved"
+      "contention_id" => "87654"
+    )
+  end
+
+  let(:decision_with_invalid_attr_names) do
+    base_decision.merge(
+      "invalid_attr" => "key",
+      "second_invalid_attr" => 44_494
     )
   end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-61140](https://jira.devops.va.gov/browse/APPEALS-61140)

# Description
Added class called `Transformers::DecisionReviewCompleted` used to create a plain old ruby object for `DecisionReviewCompletedEvent`

Added class called `DecisionReviewIssueCompleted` used to create a plain old ruby object for the contents of `Transformers::DecisionReviewCompleted`'s `decision_review_issue_completed` array

Added class called `CompletedDecision` used to create a plain old ruby object for the contents of `DecisionReviewIssueCompleted`'s `decision` field

Added `decision_review_completed_context` Rspec context to mock `DecisionReviewCompletedEvent` payload contents for all future `DecisionReviewCompleted` testing

## Acceptance Criteria
- [x] The `DecisionReviewCompleted` active model will consist of a class called `Transformers::DecisionReviewCompleted` with the following attributes:
- `claim_id`, Integer
- `decision_review_type`, String or NilClass
- `veteran_participant_id`, String or NilClass
- `claimant_participant_id`, String or NilClass
- `remand_created`, Boolean or NilClass
- `ep_code_category`, String or NilClass
- `claim_lifecycle_status`, String or NilClass
- `actor_username`, String or NilClass
- `actor_application`, String or NilClass
- `completion_time`, String or NilClass
- `decision_review_issues_created`, Array

- [x] A class called `DecisionReviewIssueCompleted` with the following attributes:
- `decision_review_issue_id`, Integer
- `contention_id`, Integer or NilClass
- `remand_claim_id`, String or NilClass
- `remand_contention_id`, String or NilClass
- `unidentified`, boolean or NilClass
- `prior_rating_decision_id`, Integer or NilClass
- `prior_non_rating_decision_id`, Integer or NilClass
- `prior_caseflow_decision_issue_id`, Integer or NilClass
- `prior_decision_rating_sn`, String or NilClass
- `prior_decision_text`, String or NilClass
- `prior_decision_type`, String or NilClass
- `prior_decision_source`, String or NilClass
- `prior_decision_notification_date`, date or NilClass
- `legacy_appeal_issue_id`, Integer or NilClass
- `prior_decision_rating_profile_date`, string or NilClass
- `soc_opt_in`, boolean or NilClass
- `legacy_appeal_id`, Integer or NilClass
- `decision`, Hash or NilClass

- [x] A class called `CompletedDecision` with the following attributes:
- `contention_id`, Integer
- `disposition`, String
- `dta_error_explanation`, String or NilClass
- `decision_source`, String or NilClass
- `category`, String or NilClass
- `decision_id`, Integer or NilClass
- `decision_text`, String or NilClass
- `award_event_id`, Integer or NilClass
- `rating_profile_date`, String or NilClass
- `decision_recorded_time`, String or NilClass
- `decision_finalized_time`, String or NilClass

- [x] All classes will include a module that validates the class's attribute names and data types when attempting to create a `DecisionReviewCompleted` instance

- [x] RSPEC exists for this model and has 100% code coverage.

- [x] Jira Testing Exists.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [APPEALS-63117](https://jira.devops.va.gov/browse/APPEALS-63117)
2. [APPEALS-63109](https://jira.devops.va.gov/browse/APPEALS-63109)
3. [Jira Xray](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-63117&testIssueKey=APPEALS-63109)

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

