### PR TITLE
Griffin/APPEALS-66494

### DIFF
--- a/app/models/builders/decision_review_created/claim_review_builder.rb
+++ b/app/models/builders/decision_review_created/claim_review_builder.rb
@@ -30,6 +30,7 @@ class Builders::DecisionReviewCreated::ClaimReviewBuilder
     calculate_establishment_submitted_at
     assign_informal_conference
     assign_same_office
+    assign_auto_remand
   end
 
   private
@@ -76,6 +77,10 @@ class Builders::DecisionReviewCreated::ClaimReviewBuilder
 
   def assign_same_office
     @claim_review.same_office = decision_review_model.same_station_review_requested
+  end
+
+  def assign_auto_remand
+    @claim_review.auto_remand = decision_review_model.auto_remand
   end
 
   def determine_benefit_type

--- a/app/models/builders/decision_review_created/dto_builder.rb
+++ b/app/models/builders/decision_review_created/dto_builder.rb
@@ -93,6 +93,7 @@ class Builders::DecisionReviewCreated::DtoBuilder < Builders::BaseDtoBuilder
 
   def build_payload
     {
+      "auto_remand": @auto_remand,
       "event_id": @event_id,
       "claim_id": @claim_id,
       "css_id": @css_id,

--- a/app/models/builders/decision_review_created/dto_builder.rb
+++ b/app/models/builders/decision_review_created/dto_builder.rb
@@ -37,6 +37,7 @@ class Builders::DecisionReviewCreated::DtoBuilder < Builders::BaseDtoBuilder
 
   # :reek:TooManyStatements
   def assign_from_decision_review_created
+    @auto_remand = @decision_review_created.auto_remand
     @claim_id = @decision_review_created.claim_id
     @css_id = @decision_review_created.actor_username
     @detail_type = @intake.detail_type

--- a/app/models/builders/decision_review_created/request_issue_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_builder.rb
@@ -9,6 +9,20 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder < Builders::BaseReque
     super(issue, decision_review_model, bis_rating_profiles, @request_issue)
   end
 
+  def assign_methods
+    super
+    assign_source_claim_id_for_remand
+    assign_source_contention_id_for_remand
+  end
+
+  def assign_source_claim_id_for_remand
+    @request_issue.source_claim_id_for_remand = issue.source_claim_id_for_remand
+  end
+
+  def assign_source_contention_id_for_remand
+    @request_issue.source_contention_id_for_remand = issue.source_contention_id_for_remand
+  end
+
   # ineligible issues are closed upon creation
   def calculate_closed_at
     @request_issue.closed_at = ineligible? ? claim_creation_time_converted_to_timestamp_ms : nil

--- a/app/models/builders/decision_review_created/request_issue_builder.rb
+++ b/app/models/builders/decision_review_created/request_issue_builder.rb
@@ -9,6 +9,8 @@ class Builders::DecisionReviewCreated::RequestIssueBuilder < Builders::BaseReque
     super(issue, decision_review_model, bis_rating_profiles, @request_issue)
   end
 
+  private
+
   def assign_methods
     super
     assign_source_claim_id_for_remand

--- a/app/models/virtual/decision_review_created/claim_review.rb
+++ b/app/models/virtual/decision_review_created/claim_review.rb
@@ -4,5 +4,6 @@
 class DecisionReviewCreated::ClaimReview
   attr_accessor :filed_by_va_gov, :receipt_date, :legacy_opt_in_approved, :veteran_is_not_claimant,
                 :informal_conference, :same_office, :benefit_type, :establishment_attempted_at,
-                :establishment_last_submitted_at, :establishment_processed_at, :establishment_submitted_at
+                :establishment_last_submitted_at, :establishment_processed_at, :establishment_submitted_at,
+                :auto_remand
 end

--- a/app/models/virtual/decision_review_created/request_issue.rb
+++ b/app/models/virtual/decision_review_created/request_issue.rb
@@ -2,4 +2,5 @@
 
 # This class should be instantiated via Builders::DecisionReviewCreated::RequestIssueBuilder
 class DecisionReviewCreated::RequestIssue < BaseRequestIssue
+  attr_accessor :source_claim_id_for_remand, :source_contention_id_for_remand
 end

--- a/spec/factories/decision_review_created.rb
+++ b/spec/factories/decision_review_created.rb
@@ -242,6 +242,42 @@ FactoryBot.define do
       end
     end
 
+    trait :with_claim_and_contention_ids_for_remand do
+      decision_review_issues_created do
+        [
+          {
+            "decision_review_issue_id" => 777,
+            "contention_id" => 123_456_789,
+            "prior_caseflow_decision_issue_id" => nil,
+            "associated_caseflow_request_issue_id" => nil,
+            "unidentified" => false,
+            "prior_rating_decision_id" => nil,
+            "prior_non_rating_decision_id" => 12,
+            "prior_decision_award_event_id" => 17_946,
+            "prior_decision_text" => "DIC: Service connection for tetnus denied",
+            "prior_decision_type" => "DIC",
+            "prior_decision_notification_date" => "2023-08-01",
+            "prior_decision_date" => "2023-08-01",
+            "prior_decision_diagnostic_code" => nil,
+            "prior_decision_rating_sn" => nil,
+            "prior_decision_rating_percentage" => nil,
+            "prior_decision_rating_profile_date" => nil,
+            "eligible" => true,
+            "eligibility_result" => "ELIGIBLE",
+            "time_override" => nil,
+            "time_override_reason" => nil,
+            "contested" => nil,
+            "soc_opt_in" => nil,
+            "legacy_appeal_id" => nil,
+            "legacy_appeal_issue_id" => nil,
+            "source_contention_id_for_remand" => 523_407,
+            "source_claim_id_for_remand" => 143_296,
+            "prior_decision_source" => nil
+          }
+        ]
+      end
+    end
+
     trait :with_invalid_decision_review_issue_created_data_type do
       decision_review_issues_created { [{ "decision_review_issue_id" => "777" }] }
     end

--- a/spec/models/builders/decision_review_created/claim_review_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/claim_review_builder_spec.rb
@@ -41,6 +41,7 @@ describe Builders::DecisionReviewCreated::ClaimReviewBuilder do
       expect(builder).to receive(:calculate_establishment_submitted_at)
       expect(builder).to receive(:assign_informal_conference)
       expect(builder).to receive(:assign_same_office)
+      expect(builder).to receive(:assign_auto_remand)
 
       builder.assign_attributes
     end
@@ -162,6 +163,13 @@ describe Builders::DecisionReviewCreated::ClaimReviewBuilder do
     subject { builder.send(:assign_same_office) }
     it "assigns claim_review's same_office to decision_reciew_created.same_station_review_requested" do
       expect(subject).to eq(decision_review_model.same_station_review_requested)
+    end
+  end
+
+  describe "#assign_auto_remand" do
+    subject { builder.send(:assign_auto_remand) }
+    it "assigns claim_review's auto_remand to decision_reciew_created.auto_remand" do
+      expect(subject).to eq(decision_review_model.auto_remand)
     end
   end
 end

--- a/spec/models/builders/decision_review_created/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/dto_builder_spec.rb
@@ -220,6 +220,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
           expect(drc_dto_builder.instance_variable_get(:@request_issues)).to be_instance_of(Array)
           expect(drc_dto_builder.instance_variable_get(:@request_issues).flatten.first)
             .to be_instance_of(DecisionReviewCreated::RequestIssue)
+          expect(drc_dto_builder.instance_variable_get(:@auto_remand)).to eq(false)
         end
       end
 
@@ -322,6 +323,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
         drc_dto_builder.instance_variable_set(:@css_id, 1)
         drc_dto_builder.instance_variable_set(:@detail_type, "HIGHER_LEVEL_REVIEW")
         drc_dto_builder.instance_variable_set(:@station, "101")
+        drc_dto_builder.instance_variable_set(:@auto_remand, true)
         drc_dto_builder.instance_variable_set(:@intake, DecisionReviewCreated::Intake.new)
         drc_dto_builder.instance_variable_set(:@veteran, DecisionReviewCreated::Veteran.new)
         drc_dto_builder.instance_variable_set(:@claimant, DecisionReviewCreated::Claimant.new)
@@ -335,6 +337,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
         expect(built_hash["css_id"]).to eq 1
         expect(built_hash["detail_type"]).to eq "HIGHER_LEVEL_REVIEW"
         expect(built_hash["station"]).to eq "101"
+        expect(built_hash["auto_remand"]).to eq true
         expect(built_hash["intake"].blank?).to eq true
         expect(built_hash["veteran"].blank?).to eq true
         expect(built_hash["claimant"].blank?).to eq true

--- a/spec/models/builders/decision_review_created/dto_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/dto_builder_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe Builders::DecisionReviewCreated::DtoBuilder, type: :model do
         expect(drc_dto_builder.instance_variable_get(:@vet_file_number)).to eq drc.file_number
         expect(drc_dto_builder.instance_variable_get(:@vet_first_name)).to eq drc.veteran_first_name
         expect(drc_dto_builder.instance_variable_get(:@vet_last_name)).to eq drc.veteran_last_name
+        expect(drc_dto_builder.instance_variable_get(:@auto_remand)).to eq drc.auto_remand
       end
     end
 

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -54,6 +54,8 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(subject.instance_variable_defined?(:@type)).to be_truthy
       expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_id)).to be_truthy
       expect(subject.instance_variable_defined?(:@nonrating_issue_bgs_source)).to be_truthy
+      expect(subject.instance_variable_defined?(:@source_claim_id_for_remand)).to be_truthy
+      expect(subject.instance_variable_defined?(:@source_contention_id_for_remand)).to be_truthy
     end
 
     it "returns the Request Issue" do
@@ -99,6 +101,8 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
       expect(builder).to receive(:assign_vacols_sequence_id)
       expect(builder).to receive(:assign_nonrating_issue_bgs_id)
       expect(builder).to receive(:assign_type)
+      expect(builder).to receive(:assign_source_claim_id_for_remand)
+      expect(builder).to receive(:assign_source_contention_id_for_remand)
 
       builder.send(:assign_methods)
     end

--- a/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
+++ b/spec/models/builders/decision_review_created/request_issue_builder_spec.rb
@@ -289,6 +289,48 @@ describe Builders::DecisionReviewCreated::RequestIssueBuilder do
     end
   end
 
+  describe "#assign_source_claim_id_for_remand" do
+    subject { builder.send(:assign_source_claim_id_for_remand) }
+
+    context "when the issue has a source_claim_id_for_remand" do
+      let(:decision_review_model) do
+        build(:decision_review_created, :with_claim_and_contention_ids_for_remand)
+      end
+
+      it "assigns the Request Issue's source_claim_id_for_remand to issue.source_claim_id_for_remand" do
+        expect(subject).to eq(issue.source_claim_id_for_remand)
+        expect(subject).not_to be_nil
+      end
+    end
+
+    context "when the issue's source_claim_id_for_remand field is nil" do
+      it "assigns the Request Issue's source_claim_id_for_remand to nil" do
+        expect(subject).to eq(nil)
+      end
+    end
+  end
+
+  describe "#assign_source_contention_id_for_remand" do
+    subject { builder.send(:assign_source_contention_id_for_remand) }
+
+    context "when the issue has a source_contention_id_for_remand" do
+      let(:decision_review_model) do
+        build(:decision_review_created, :with_claim_and_contention_ids_for_remand)
+      end
+
+      it "assigns the Request Issue's source_contention_id_for_remand to issue.source_contention_id_for_remand" do
+        expect(subject).to eq(issue.source_contention_id_for_remand)
+        expect(subject).not_to be_nil
+      end
+    end
+
+    context "when the issue's source_contention_id_for_remand field is nil" do
+      it "assigns the Request Issue's source_contention_id_for_remand to nil" do
+        expect(subject).to eq(nil)
+      end
+    end
+  end
+
   describe "#calculate_contested_rating_issue_profile_date" do
     subject { builder.send(:calculate_contested_rating_issue_profile_date) }
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-66494](https://jira.devops.va.gov/browse/APPEALS-66494)

# Description
Adds three attributes to the `DecisionReviewCreated` event payload involved in the remand workflow:
- `auto_remand`, boolean
   - in the base level of the `DecisionReviewCreated` data transfer object
   - in the `claim_review` of the `DecisionReviewCreated` data transfer object
- `source_claim_id_for_remand`, integer
   - in the `request_issue` of the `DecisionReviewCreated` data transfer object
- `source_contention_id_for_remand`, integer
   - in the `request_issue` of the `DecisionReviewCreated` data transfer object

## Acceptance Criteria
- [x] Code compiles correctly

### The following Attributes that must be added to the appropriate DecisionReviewCreated models and Builder classes are:
- [x] `AutoRemand`, boolean
  - included at the base level of the `DecisionReviewCreated` Data Transfer Object
  - Assignment Statement added within the `#assign_from_decision_review_created` method in the `Builders::DecisionReviewCreated::DtoBuilder` class
  - Added to the `DecisionReviewCreated::ClaimReview` model
  - included within each `ClaimReview` object as part of the `DecisionReviewCreated` Data Transfer Object
  - Assignment Statement added within the `#assign_methods` method in the `DecisionReviewCreated::ClaimReview` class
- [x] `SourceClaimIDForRemand`,  Integer
  - included within each `RequestIssue` object as part of the `DecisionReviewCreated` Data Transfer Object
  - Added to the `DecisionReviewCreated::RequestIssue` model
  - Assignment Statement added within the `#assign_methods` method in the `Builders::BaseRequestIssueBuilder` class
- [x] `SourceContentionIDForRemand`, Integer
  - included within each `RequestIssue` object as part of the `DecisionReviewCreated` Data Transfer Object
  - Added to the `DecisionReviewCreated::RequestIssue` model
  - Assignment Statement added within the `#assign_methods` method in the `Builders::BaseRequestIssueBuilder` class

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [Jira Xray](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-67399&testIssueKey=APPEALS-67167)
2. [APPEALS-67167](https://jira.devops.va.gov/browse/APPEALS-67167)
3. [APPEALS-67399](https://jira.devops.va.gov/browse/APPEALS-67399)

# Best practices
## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
