### PR TITLE
Set the kafka image to be version 7.7.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   kafka:
     container_name: kafka
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:7.7.2
     ports:
       - 9092:9092
     environment:


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-66670](https://jira.devops.va.gov/browse/APPEALS-66670)

# Description
Updated the specific version of the image we want for kafka. Originally it was setting it to default which points to latest (7.8) which was causing the containers to get stuck. Setting the version 7.7.2 fixes the stuck container. 

## Acceptance Criteria
- [x] Code compiles correctly
- [x] All Rspec/Unit test pass

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [Test Plan Link - APPEALS-66674](https://jira.devops.va.gov/browse/APPEALS-66674)
2. [Test Exec XRay Link- APPEALS-66675](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-66675&testIssueKey=APPEALS-66674)
3. [Test Exec Link- APPEALS-66675](https://jira.devops.va.gov/browse/APPEALS-66675)
